### PR TITLE
fix: sync __version__ to 0.7.1 and guard None git ref in incremental update

### DIFF
--- a/src/token_savior/__init__.py
+++ b/src/token_savior/__init__.py
@@ -1,3 +1,3 @@
 """Structural codebase indexer with MCP server for AI-assisted development."""
 
-__version__ = "0.4.2"
+__version__ = "0.7.1"

--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -723,6 +723,12 @@ def _maybe_incremental_update(slot: _ProjectSlot) -> None:
     slot._last_update_check = now
 
     idx = slot.indexer._project_index
+    if idx.last_indexed_git_ref is None:
+        # No git ref recorded (e.g. empty repo or first index on non-git).
+        # Trigger a full rebuild so the index gets a git ref for future checks.
+        _build_slot(slot)
+        return
+
     changeset = get_changed_files(slot.root, idx.last_indexed_git_ref)
     if changeset.is_empty:
         return


### PR DESCRIPTION
## Changes

### `__init__.py`
`__version__` was hardcoded as `0.4.2`, out of sync with `pyproject.toml` which declares `0.7.1`. This causes `token_savior.__version__` to return wrong value at runtime.

### `server.py` — `_maybe_incremental_update()`
The function called `get_changed_files(slot.root, idx.last_indexed_git_ref)` without checking if `last_indexed_git_ref` is `None` first. `get_changed_files()` already handles `None` by returning an empty changeset (safe), but this meant the incremental update path would silently skip forever on repos where the initial index didn't record a git ref (empty repo, non-standard git setup). Now triggers a full rebuild in that case so a ref gets recorded.

---
*Spotted while evaluating the project.*