### PR TITLE
feat(go): add intra-file dependency graph to go_annotator

### DIFF
--- a/src/token_savior/go_annotator.py
+++ b/src/token_savior/go_annotator.py
@@ -16,6 +16,27 @@ from token_savior.models import (
     StructuralMetadata,
 )
 
+# ---------------------------------------------------------------------------
+# Dependency graph helpers
+# ---------------------------------------------------------------------------
+
+_IDENT_RE = re.compile(r"\b([A-Za-z_]\w*)\b")
+
+_GO_KEYWORDS = frozenset({
+    # Language keywords
+    "break", "case", "chan", "const", "continue", "default", "defer",
+    "else", "fallthrough", "for", "func", "go", "goto", "if", "import",
+    "interface", "map", "package", "range", "return", "select", "struct",
+    "switch", "type", "var",
+    # Built-in identifiers and types
+    "append", "any", "bool", "byte", "cap", "clear", "close", "complex",
+    "complex64", "complex128", "copy", "delete", "error", "false",
+    "float32", "float64", "imag", "int", "int8", "int16", "int32", "int64",
+    "iota", "len", "make", "max", "min", "new", "nil", "panic", "print",
+    "println", "real", "recover", "rune", "string", "true", "uint", "uint8",
+    "uint16", "uint32", "uint64", "uintptr",
+})
+
 
 def _build_line_offsets(text: str, lines: list[str]) -> list[int]:
     offsets: list[int] = []
@@ -24,6 +45,34 @@ def _build_line_offsets(text: str, lines: list[str]) -> list[int]:
         offsets.append(pos)
         pos += len(line) + 1
     return offsets
+
+
+def _build_dependency_graph(
+    functions: list[FunctionInfo],
+    classes: list[ClassInfo],
+    lines: list[str],
+    defined_names: set[str],
+) -> dict[str, list[str]]:
+    """Build intra-file dependency graph for functions and structs."""
+    graph: dict[str, list[str]] = {}
+
+    for func in functions:
+        start = func.line_range.start - 1  # 0-indexed
+        end = func.line_range.end  # exclusive
+        body_text = "\n".join(lines[start:end])
+        refs = set(_IDENT_RE.findall(body_text))
+        deps = sorted((refs & defined_names) - {func.name} - _GO_KEYWORDS)
+        graph[func.name] = deps
+
+    for cls in classes:
+        start = cls.line_range.start - 1
+        end = cls.line_range.end
+        body_text = "\n".join(lines[start:end])
+        refs = set(_IDENT_RE.findall(body_text))
+        deps = sorted((refs & defined_names) - {cls.name} - _GO_KEYWORDS)
+        graph[cls.name] = deps
+
+    return graph
 
 
 # ---------------------------------------------------------------------------
@@ -453,6 +502,10 @@ def annotate_go(source: str, source_name: str = "<source>") -> StructuralMetadat
         else:
             updated_classes.append(cls)
 
+    # Build intra-file dependency graph
+    defined_names = {f.name for f in functions} | {c.name for c in updated_classes}
+    dependency_graph = _build_dependency_graph(functions, updated_classes, lines, defined_names)
+
     return StructuralMetadata(
         source_name=source_name,
         total_lines=total_lines,
@@ -462,4 +515,5 @@ def annotate_go(source: str, source_name: str = "<source>") -> StructuralMetadat
         functions=functions,
         classes=updated_classes,
         imports=imports,
+        dependency_graph=dependency_graph,
     )

--- a/tests/test_markup_go.py
+++ b/tests/test_markup_go.py
@@ -348,3 +348,98 @@ class TestGoEdgeCases:
         meta = annotate_go(src)
         assert len(meta.functions) == 1
         assert meta.functions[0].name == "query"
+
+
+class TestGoDependencyGraph:
+    """Tests for intra-file dependency graph construction."""
+
+    def test_empty_dependency_graph_for_independent_functions(self):
+        src = (
+            "func foo() int {\n"
+            "\treturn 1\n"
+            "}\n"
+            "\n"
+            "func bar() int {\n"
+            "\treturn 2\n"
+            "}\n"
+        )
+        meta = annotate_go(src)
+        assert "foo" in meta.dependency_graph
+        assert "bar" in meta.dependency_graph
+        assert meta.dependency_graph["foo"] == []
+        assert meta.dependency_graph["bar"] == []
+
+    def test_function_calling_another_function(self):
+        src = (
+            "func helper() int {\n"
+            "\treturn 42\n"
+            "}\n"
+            "\n"
+            "func main() {\n"
+            "\tv := helper()\n"
+            "\t_ = v\n"
+            "}\n"
+        )
+        meta = annotate_go(src)
+        assert "helper" in meta.dependency_graph["main"]
+        assert "main" not in meta.dependency_graph["helper"]
+
+    def test_method_calling_sibling_method(self):
+        src = (
+            "type Service struct{}\n"
+            "\n"
+            "func (s *Service) init() {}\n"
+            "\n"
+            "func (s *Service) Start() {\n"
+            "\ts.init()\n"
+            "}\n"
+        )
+        meta = annotate_go(src)
+        # init is referenced inside Start body
+        assert "init" in meta.dependency_graph["Start"]
+
+    def test_go_keywords_excluded_from_deps(self):
+        src = (
+            "func process() {\n"
+            "\tfor i := range []int{} {\n"
+            "\t\tif i > 0 {\n"
+            "\t\t\treturn\n"
+            "\t\t}\n"
+            "\t}\n"
+            "}\n"
+        )
+        meta = annotate_go(src)
+        deps = meta.dependency_graph.get("process", [])
+        for kw in ("for", "range", "if", "return"):
+            assert kw not in deps
+
+    def test_struct_referencing_other_struct(self):
+        src = (
+            "type Config struct {\n"
+            "\tTimeout int\n"
+            "}\n"
+            "\n"
+            "type Server struct {\n"
+            "\tcfg Config\n"
+            "}\n"
+        )
+        meta = annotate_go(src)
+        assert "Config" in meta.dependency_graph["Server"]
+
+    def test_dependency_graph_keys_match_defined_symbols(self):
+        src = (
+            "func alpha() {}\n"
+            "func beta() { alpha() }\n"
+            "type Gamma struct{}\n"
+        )
+        meta = annotate_go(src)
+        assert set(meta.dependency_graph.keys()) >= {"alpha", "beta", "Gamma"}
+
+    def test_no_self_dependency(self):
+        src = (
+            "func recursive() {\n"
+            "\trecursive()\n"
+            "}\n"
+        )
+        meta = annotate_go(src)
+        assert "recursive" not in meta.dependency_graph["recursive"]


### PR DESCRIPTION
## Summary

Closes #6.

`go_annotator.py` was missing `_build_dependency_graph()`, which caused `get_dependencies`, `get_dependents`, and `get_change_impact` to return empty results for all Go symbols.

### Changes

- **`src/token_savior/go_annotator.py`**
  - Add `_GO_KEYWORDS` frozenset (language keywords + built-in identifiers to exclude from dependency refs)
  - Add `_IDENT_RE` regex for identifier extraction
  - Add `_build_dependency_graph(functions, classes, lines, defined_names)` — mirrors the equivalent in `c_annotator.py`; scans each function/struct body with regex to find references to names defined in the same file
  - Call `_build_dependency_graph()` at the end of `annotate_go()` and include the result in the returned `StructuralMetadata`

- **`tests/test_markup_go.py`**
  - Add `TestGoDependencyGraph` class with 7 tests covering: independent functions, caller/callee relationships, method cross-references, keyword exclusion, struct→struct refs, key set completeness, and self-dependency exclusion

## Test plan

- [x] `pytest tests/test_markup_go.py -v` — 42 passed (35 existing + 7 new)
- [x] `pytest tests/ -q` — 878 passed, no regressions