### PR TITLE
feat(indexer): exclude .gitignore paths and add TOKEN_SAVIOR_EXCLUDE_PATTERNS

### DIFF
--- a/src/token_savior/project_indexer.py
+++ b/src/token_savior/project_indexer.py
@@ -20,6 +20,55 @@ logger = logging.getLogger(__name__)
 _WORD_BOUNDARY_CACHE: dict[str, re.Pattern] = {}
 
 
+def _parse_gitignore(root_path: str) -> list[str]:
+    """Read .gitignore from root_path and convert entries to fnmatch exclude patterns.
+
+    Handles the most common gitignore syntax:
+    - blank lines and ``#`` comments are skipped
+    - ``!`` negation patterns are skipped (too complex to invert safely)
+    - a trailing ``/`` marks a directory-only pattern
+    - a leading ``/`` marks a root-relative pattern; stripped before conversion
+    - all other patterns are treated as anywhere-in-tree patterns
+
+    Returns a list of patterns compatible with ``_is_excluded`` / fnmatch.
+    """
+    gitignore = os.path.join(root_path, ".gitignore")
+    if not os.path.isfile(gitignore):
+        return []
+
+    patterns: list[str] = []
+    try:
+        with open(gitignore, encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.rstrip("\n").rstrip("\r")
+
+                # skip comments and blanks
+                if not line or line.startswith("#"):
+                    continue
+                # skip negation patterns
+                if line.startswith("!"):
+                    continue
+
+                is_dir_only = line.endswith("/")
+                # strip leading/trailing slashes for normalization
+                line = line.strip("/")
+                if not line:
+                    continue
+
+                if is_dir_only:
+                    # match the directory itself and anything inside it
+                    patterns.append(f"**/{line}/**")
+                    patterns.append(f"{line}/**")
+                else:
+                    # file or generic pattern: match anywhere in tree
+                    patterns.append(f"**/{line}")
+                    patterns.append(f"**/{line}/**")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.debug("Could not read .gitignore at %s: %s", gitignore, exc)
+
+    return patterns
+
+
 def _word_boundary_re(name: str) -> re.Pattern:
     pat = _WORD_BOUNDARY_CACHE.get(name)
     if pat is None:
@@ -100,6 +149,8 @@ class ProjectIndexer:
             "**/_deps/**",
             # Claude Code worktrees (duplicates of the project)
             "**/.claude/worktrees/**",
+            # git worktrees checked out inside the repo
+            "**/.worktrees/**",
         ]
         self.max_file_size_bytes = max_file_size_bytes or int(
             os.environ.get("TOKEN_SAVIOR_MAX_FILE_SIZE", "500000")
@@ -107,6 +158,18 @@ class ProjectIndexer:
         self.max_files = max_files or int(
             os.environ.get("TOKEN_SAVIOR_MAX_FILES", "10000")
         )
+
+        # Append patterns from .gitignore (when caller didn't supply custom excludes)
+        if exclude_patterns is None:
+            self.exclude_patterns.extend(_parse_gitignore(self.root_path))
+
+        # Append patterns from TOKEN_SAVIOR_EXCLUDE_PATTERNS env var (colon-separated)
+        env_excludes = os.environ.get("TOKEN_SAVIOR_EXCLUDE_PATTERNS", "")
+        if env_excludes:
+            self.exclude_patterns.extend(
+                p.strip() for p in env_excludes.split(":") if p.strip()
+            )
+
         self._project_index: ProjectIndex | None = None
 
     # ------------------------------------------------------------------
@@ -452,15 +515,19 @@ class ProjectIndexer:
         """Check if a relative path matches any exclude pattern."""
         # Normalize separators to forward slashes for matching
         normalized = rel_path.replace(os.sep, "/")
+        parts = normalized.split("/")
         for pattern in self.exclude_patterns:
             if fnmatch.fnmatch(normalized, pattern):
                 return True
-            # Also check if any path component matches
-            # e.g., "__pycache__" in the path
-            parts = normalized.split("/")
-            # Check simple directory name exclusions
+            # For patterns starting with "**/" strip the prefix and retry.
+            # fnmatch's "*" matches "/" so "*.log" matches "sub/dir/file.log".
+            if pattern.startswith("**/"):
+                if fnmatch.fnmatch(normalized, pattern[3:]):
+                    return True
+            # Also check if any path component matches a simple name
+            # e.g., "__pycache__" or ".worktrees" present as a directory segment
             pattern_parts = pattern.replace("**/", "").replace("/**", "").strip("/")
-            if pattern_parts in parts:
+            if "/" not in pattern_parts and pattern_parts in parts:
                 return True
         return False
 

--- a/tests/test_project_indexer.py
+++ b/tests/test_project_indexer.py
@@ -16,7 +16,7 @@ import textwrap
 
 import pytest
 
-from token_savior.project_indexer import ProjectIndexer
+from token_savior.project_indexer import ProjectIndexer, _parse_gitignore
 
 
 # ---------------------------------------------------------------------------
@@ -656,6 +656,162 @@ class TestRustProject:
         if lib_path in idx.import_graph:
             imports = idx.import_graph[lib_path]
             assert models_path in imports or utils_path in imports
+
+
+class TestParseGitignore:
+    """Tests for the _parse_gitignore helper."""
+
+    def test_returns_empty_when_no_gitignore(self, tmp_path):
+        patterns = _parse_gitignore(str(tmp_path))
+        assert patterns == []
+
+    def test_skips_comments_and_blanks(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("# comment\n\n*.log\n")
+        patterns = _parse_gitignore(str(tmp_path))
+        assert any("*.log" in p for p in patterns)
+        # comment and blank lines should not produce extra patterns
+        assert not any("comment" in p for p in patterns)
+
+    def test_directory_pattern_produces_glob(self, tmp_path):
+        (tmp_path / ".gitignore").write_text(".worktrees/\n")
+        patterns = _parse_gitignore(str(tmp_path))
+        assert "**/.worktrees/**" in patterns
+
+    def test_file_pattern_produces_anywhere_glob(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("*.log\n")
+        patterns = _parse_gitignore(str(tmp_path))
+        assert "**/*.log" in patterns
+
+    def test_negation_patterns_skipped(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("!important.log\n")
+        patterns = _parse_gitignore(str(tmp_path))
+        assert patterns == []
+
+    def test_leading_slash_stripped(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("/build/\n")
+        patterns = _parse_gitignore(str(tmp_path))
+        assert "**/.worktrees/**" not in patterns
+        assert any("build" in p for p in patterns)
+
+
+class TestGitignoreExclusion:
+    """Tests for file discovery respecting .gitignore patterns."""
+
+    def test_gitignored_directory_excluded_from_index(self, tmp_path):
+        """Files inside a gitignored directory should not appear in the index."""
+        # Create .gitignore that ignores .worktrees/
+        (tmp_path / ".gitignore").write_text(".worktrees/\n")
+
+        # Create source files: one real, one in ignored dir
+        src = tmp_path / "main.py"
+        src.write_text("def hello(): pass\n")
+
+        wt_dir = tmp_path / ".worktrees" / "feat-branch" / "app"
+        wt_dir.mkdir(parents=True)
+        (wt_dir / "server.py").write_text("def serve(): pass\n")
+
+        indexer = ProjectIndexer(str(tmp_path), include_patterns=["**/*.py"])
+        idx = indexer.index()
+
+        indexed_paths = list(idx.files.keys())
+        assert any("main.py" in p for p in indexed_paths)
+        assert not any(".worktrees" in p for p in indexed_paths)
+
+    def test_gitignore_file_pattern_excludes_matching_files(self, tmp_path):
+        """Files matching a .gitignore glob should be excluded."""
+        (tmp_path / ".gitignore").write_text("*.generated.py\n")
+
+        (tmp_path / "real.py").write_text("def real(): pass\n")
+        (tmp_path / "auto.generated.py").write_text("def generated(): pass\n")
+
+        indexer = ProjectIndexer(str(tmp_path), include_patterns=["**/*.py"])
+        idx = indexer.index()
+
+        indexed_paths = list(idx.files.keys())
+        assert any("real.py" in p for p in indexed_paths)
+        assert not any("auto.generated.py" in p for p in indexed_paths)
+
+    def test_custom_exclude_patterns_override_gitignore(self, tmp_path):
+        """Explicitly passed exclude_patterns skip .gitignore loading."""
+        (tmp_path / ".gitignore").write_text("ignored_dir/\n")
+
+        (tmp_path / "file.py").write_text("x = 1\n")
+        ignored = tmp_path / "ignored_dir"
+        ignored.mkdir()
+        (ignored / "other.py").write_text("y = 2\n")
+
+        # Pass custom exclude_patterns — .gitignore should NOT be applied
+        indexer = ProjectIndexer(
+            str(tmp_path),
+            include_patterns=["**/*.py"],
+            exclude_patterns=["**/node_modules/**"],  # custom, doesn't exclude ignored_dir
+        )
+        idx = indexer.index()
+
+        indexed_paths = list(idx.files.keys())
+        # ignored_dir/other.py should be indexed because gitignore was not applied
+        assert any("other.py" in p for p in indexed_paths)
+
+    def test_worktrees_excluded_by_default(self, tmp_path):
+        """The .worktrees/ directory is excluded even without a .gitignore."""
+        (tmp_path / "app.py").write_text("def app(): pass\n")
+
+        wt = tmp_path / ".worktrees" / "my-branch"
+        wt.mkdir(parents=True)
+        (wt / "app.py").write_text("def app(): pass\n")
+
+        indexer = ProjectIndexer(str(tmp_path), include_patterns=["**/*.py"])
+        idx = indexer.index()
+
+        indexed_paths = list(idx.files.keys())
+        assert not any(".worktrees" in p for p in indexed_paths)
+
+
+class TestExcludePatternsEnvVar:
+    """Tests for TOKEN_SAVIOR_EXCLUDE_PATTERNS environment variable."""
+
+    def test_env_var_patterns_applied(self, tmp_path, monkeypatch):
+        """Patterns from TOKEN_SAVIOR_EXCLUDE_PATTERNS are excluded."""
+        monkeypatch.setenv("TOKEN_SAVIOR_EXCLUDE_PATTERNS", "**/secret/**")
+
+        (tmp_path / "public.py").write_text("def pub(): pass\n")
+        sec = tmp_path / "secret"
+        sec.mkdir()
+        (sec / "private.py").write_text("def priv(): pass\n")
+
+        indexer = ProjectIndexer(str(tmp_path), include_patterns=["**/*.py"])
+        idx = indexer.index()
+
+        indexed_paths = list(idx.files.keys())
+        assert any("public.py" in p for p in indexed_paths)
+        assert not any("private.py" in p for p in indexed_paths)
+
+    def test_env_var_colon_separated(self, tmp_path, monkeypatch):
+        """Multiple patterns can be separated by colons."""
+        monkeypatch.setenv("TOKEN_SAVIOR_EXCLUDE_PATTERNS", "**/aaa/**:**/bbb/**")
+
+        (tmp_path / "main.py").write_text("x = 1\n")
+        for d in ("aaa", "bbb"):
+            (tmp_path / d).mkdir()
+            (tmp_path / d / "mod.py").write_text("y = 2\n")
+
+        indexer = ProjectIndexer(str(tmp_path), include_patterns=["**/*.py"])
+        idx = indexer.index()
+
+        indexed_paths = list(idx.files.keys())
+        assert any("main.py" in p for p in indexed_paths)
+        assert not any("aaa" in p for p in indexed_paths)
+        assert not any("bbb" in p for p in indexed_paths)
+
+    def test_empty_env_var_ignored(self, tmp_path, monkeypatch):
+        """An empty TOKEN_SAVIOR_EXCLUDE_PATTERNS should not break indexing."""
+        monkeypatch.setenv("TOKEN_SAVIOR_EXCLUDE_PATTERNS", "")
+
+        (tmp_path / "ok.py").write_text("z = 3\n")
+        indexer = ProjectIndexer(str(tmp_path), include_patterns=["**/*.py"])
+        idx = indexer.index()
+
+        assert idx.total_files == 1
 
 
 class TestIntegration:


### PR DESCRIPTION
## Summary

Closes #7.

`_discover_files()` ignored `.gitignore`, so `.worktrees/` and other gitignored directories were indexed — causing duplicate symbols, stale paths in `find_symbol`, and body files being crowded out by the `TOKEN_SAVIOR_MAX_FILES` limit.

### Changes

- **`src/token_savior/project_indexer.py`**
  - Add `_parse_gitignore(root_path)` module-level helper: reads `.gitignore` from the project root and converts entries to fnmatch-compatible exclude patterns (handles `#` comments, blank lines, negation skip, directory-only `/` suffix, leading `/` strip)
  - `ProjectIndexer.__init__`: when `exclude_patterns` is not explicitly provided, append patterns from `.gitignore` via `_parse_gitignore()`
  - `ProjectIndexer.__init__`: append patterns from `TOKEN_SAVIOR_EXCLUDE_PATTERNS` env var (colon-separated) — works with both default and custom `exclude_patterns`
  - Add `"**/.worktrees/**"` to the built-in default exclude list
  - Fix `_is_excluded`: for patterns starting with `**/`, also try matching the normalized path against the pattern *without* the `**/` prefix, so wildcard file patterns like `**/*.generated.py` work correctly (fnmatch's `*` matches `/`)

- **`tests/test_project_indexer.py`**
  - Add `TestParseGitignore` (6 tests): no-gitignore case, comments/blanks skip, directory pattern → `**/<name>/**` glob, file pattern → `**/<pat>` glob, negation skip, leading-slash strip
  - Add `TestGitignoreExclusion` (4 tests): gitignored dir excluded, file glob excluded, custom `exclude_patterns` skips gitignore, `.worktrees/` excluded by default
  - Add `TestExcludePatternsEnvVar` (3 tests): env var applied, colon-separated multiple patterns, empty env var is safe

## Test plan

- [x] `pytest tests/test_project_indexer.py -k "TestParseGitignore or TestGitignoreExclusion or TestExcludePatternsEnvVar" -v` — 13 passed
- [x] `pytest tests/ -q` — 884 passed, no regressions