### PR TITLE
Semantic code tools: search_codebase + duplicates + library lookup

### DIFF
--- a/src/token_savior/db_core.py
+++ b/src/token_savior/db_core.py
@@ -232,6 +232,42 @@ def run_migrations(db_path: Path | str | None = None) -> None:
                     "vector search disabled.", exc,
                 )
 
+            # Feature 1: symbol-level vector index for search_codebase(semantic=True).
+            # vec0 demands INTEGER primary keys and a dense FLOAT[N] column, so
+            # symbol metadata (project + key) lives in a sibling mapping table
+            # and the vec row is joined via symbol_id.
+            try:
+                conn.execute(
+                    "CREATE TABLE IF NOT EXISTS symbols("
+                    "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                    "  project_root TEXT NOT NULL,"
+                    "  symbol_key TEXT NOT NULL,"
+                    "  file_path TEXT NOT NULL,"
+                    "  lineno INTEGER NOT NULL,"
+                    "  kind TEXT NOT NULL,"
+                    "  signature TEXT,"
+                    "  docstring_head TEXT,"
+                    "  content_hash TEXT NOT NULL,"
+                    "  updated_at_epoch INTEGER NOT NULL,"
+                    "  UNIQUE(project_root, symbol_key)"
+                    ")"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_symbols_proj "
+                    "ON symbols(project_root)"
+                )
+                conn.execute(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS symbol_vectors USING vec0("
+                    "  symbol_id INTEGER PRIMARY KEY,"
+                    "  embedding FLOAT[768]"
+                    ")"
+                )
+            except sqlite3.OperationalError as exc:
+                _logger.warning(
+                    "[token-savior:memory] symbol_vectors create failed (%s); "
+                    "semantic code search disabled.", exc,
+                )
+
         conn.commit()
     finally:
         conn.close()

--- a/src/token_savior/library_api.py
+++ b/src/token_savior/library_api.py
@@ -456,6 +456,130 @@ def get_library_symbol(
     }
 
 
+def find_library_symbol_by_description(
+    package: str,
+    description: str,
+    *,
+    project_root: str,
+    limit: int = 10,
+    max_files: int = 100,
+    candidate_pool: int = 200,
+) -> dict[str, Any]:
+    """Rank package exports by embedding cosine similarity to a
+    natural-language description.
+
+    Short-lived, on-the-fly index: lists every export via
+    ``list_library_symbols``, enriches each (Python path only — uses
+    ``inspect`` for docstrings / signatures; TS stays on the raw
+    declared name + kind), embeds the pool sequentially, then cosine-
+    ranks against ``embed(description, as_query=True)``. Nothing is
+    persisted — library calls are one-shot lookups, a disk index would
+    be dead weight.
+
+    SAFETY — the same caveats as ``search_codebase(semantic=True)``
+    apply: the result is a ranked suggestion list, never a trusted
+    single answer. Verify via ``get_library_symbol(package, exact_name)``
+    before acting on a hit.
+
+    Returns a dict shaped like::
+
+        {"ok": True, "package": str, "description": str,
+         "candidates_scanned": int, "hits": [{
+             "name": str, "kind": str, "score": float,
+             "doc_preview": str, "file": str|None, "line": int|None,
+         }, ...],
+         "warning": "low_confidence: ..." | None}
+    """
+    try:
+        from token_savior.memory.embeddings import embed, is_available
+    except ImportError as exc:
+        return {"ok": False, "error": f"embedding stack unavailable: {exc}"}
+    if not is_available():
+        return {"ok": False, "error": "fastembed model not loadable"}
+
+    listing = list_library_symbols(
+        package, project_root=project_root,
+        max_files=max_files, limit=candidate_pool,
+    )
+    if not listing.get("ok"):
+        return listing
+    language = listing.get("language")
+    items = listing.get("items", [])
+    if not items:
+        return {"ok": False, "error": f"no exports enumerated for {package}"}
+
+    qvec = embed(description, as_query=True)
+    if qvec is None:
+        return {"ok": False, "error": "query embedding failed"}
+
+    candidates: list[tuple[dict, list[float]]] = []
+    for item in items:
+        name = item.get("name", "")
+        kind = item.get("kind", "symbol")
+        doc = ""
+        sig = ""
+        file_ = item.get("file")
+        line = item.get("line")
+        if language == "python":
+            dotted = f"{package}.{name}" if "." not in name else name
+            detailed = _py_symbol(dotted)
+            if detailed and detailed.get("ok"):
+                doc = (detailed.get("doc") or "").strip()
+                sig = detailed.get("signature") or ""
+                file_ = detailed.get("file") or file_
+                line = detailed.get("line") or line
+        doc_head = "\n".join(doc.splitlines()[:3])
+        embed_doc = (
+            f"{kind} {name}\n"
+            f"{sig}\n"
+            f"{doc_head}"
+        ).strip()
+        vec = embed(embed_doc)
+        if vec is None:
+            continue
+        candidates.append((
+            {
+                "name": name, "kind": kind,
+                "doc_preview": doc_head[:240],
+                "file": file_, "line": line,
+            },
+            vec,
+        ))
+
+    def _cos(a: list[float], b: list[float]) -> float:
+        return sum(x * y for x, y in zip(a, b, strict=False))
+
+    scored = sorted(
+        ((cand, _cos(qvec, v)) for cand, v in candidates),
+        key=lambda t: t[1], reverse=True,
+    )
+    hits = []
+    for cand, score in scored[:limit]:
+        cand["score"] = round(max(0.0, score), 4)
+        hits.append(cand)
+
+    warning: str | None = None
+    if hits:
+        top1 = hits[0]["score"]
+        top2 = hits[1]["score"] if len(hits) > 1 else 0.0
+        if top1 < 0.75 or (top1 - top2) < 0.02:
+            warning = (
+                f"low_confidence: top1={top1:.2f}, top2={top2:.2f}. "
+                f"Verify the exact name via get_library_symbol "
+                f"before acting on any hit."
+            )
+
+    return {
+        "ok": True,
+        "language": language,
+        "package": package,
+        "description": description,
+        "candidates_scanned": len(candidates),
+        "hits": hits,
+        "warning": warning,
+    }
+
+
 def list_library_symbols(
     package: str,
     *,

--- a/src/token_savior/memory/symbol_embeddings.py
+++ b/src/token_savior/memory/symbol_embeddings.py
@@ -1,0 +1,372 @@
+"""Symbol-level vector index for `search_codebase(semantic=True)`.
+
+Mirrors the design of ``memory/embeddings.py`` but scoped to code symbols
+parsed from a project tree rather than memory observations.
+
+Schema (created in ``db_core.run_migrations``):
+
+* ``symbols(id, project_root, symbol_key, file_path, lineno, kind,
+  signature, docstring_head, content_hash, updated_at_epoch)``
+* ``symbol_vectors(symbol_id INTEGER PK, embedding FLOAT[768])``
+
+Flow:
+
+1. ``collect_project_symbols(root)`` walks ``*.py`` files, extracts
+   ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef`` via ``ast``, and
+   returns descriptors suitable for embedding.
+2. ``reindex_project_symbols(root)`` embeds new/changed symbols (batched)
+   and upserts rows. Rows whose ``content_hash`` already matches the
+   stored hash are skipped — cheap incremental reindex.
+3. ``search_symbols_semantic(query, root, limit=10)`` embeds the query
+   (``as_query=True`` prefix), runs k-NN against ``symbol_vectors``,
+   joins ``symbols`` for metadata, returns hits with scores.
+
+The module is a no-op when sqlite-vec or fastembed isn't loadable — the
+caller gets ``status="unavailable"`` and should fall back to the regex
+path. Same degradation contract as ``memory/embeddings.py``.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import logging
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+_logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 32
+_MAX_DOC_CHARS = 1200
+_EXCLUDE_DIRS = frozenset({
+    "__pycache__", ".git", "node_modules", "dist", "build", ".next",
+    "venv", ".venv", "env", ".tox",
+})
+
+
+# ---------------------------------------------------------------------------
+# AST walker — produces one descriptor per function/class/method
+# ---------------------------------------------------------------------------
+
+
+def _iter_symbols_in_file(py_path: Path, project_root: Path) -> Iterable[dict]:
+    try:
+        source = py_path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source)
+    except (OSError, SyntaxError):
+        return
+    rel_path = str(py_path.relative_to(project_root))
+
+    def _visit(node: ast.AST, prefix: str = "") -> Iterable[dict]:
+        for child in ast.iter_child_nodes(node):
+            if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            qname = f"{prefix}{child.name}" if prefix else child.name
+            kind = "class" if isinstance(child, ast.ClassDef) else "func"
+            doc = (ast.get_docstring(child) or "").strip()
+            doc_head = "\n".join(doc.splitlines()[:2])
+
+            try:
+                sig_source = ast.unparse(child)
+            except Exception:
+                sig_source = ""
+            sig_lines = sig_source.splitlines()
+            signature = sig_lines[0] if sig_lines else f"{kind} {qname}"
+
+            body_head: list[str] = []
+            skipped_doc = False
+            for line in sig_lines[1:]:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if not skipped_doc and stripped.startswith(('"""', "'''")):
+                    skipped_doc = True
+                    continue
+                body_head.append(stripped)
+                if len(body_head) >= 3:
+                    break
+            body_excerpt = "\n".join(body_head)
+
+            symbol_key = f"{rel_path}::{qname}"
+            # ``embed()`` already prepends "search_document: " — we only
+            # supply the raw payload. Double-prefix would confuse the
+            # Nomic task router.
+            embed_doc = (
+                f"{kind} {qname}\n"
+                f"{signature}\n"
+                f"{doc_head}\n"
+                f"{body_excerpt}"
+            ).strip()[:_MAX_DOC_CHARS]
+            content_hash = hashlib.sha1(
+                embed_doc.encode("utf-8", "replace")
+            ).hexdigest()[:16]
+
+            yield {
+                "project_root": str(project_root),
+                "symbol_key": symbol_key,
+                "file_path": rel_path,
+                "lineno": child.lineno,
+                "kind": kind,
+                "signature": signature[:400],
+                "docstring_head": doc_head[:400],
+                "content_hash": content_hash,
+                "embed_doc": embed_doc,
+            }
+            if isinstance(child, ast.ClassDef):
+                yield from _visit(child, prefix=f"{qname}.")
+
+    yield from _visit(tree)
+
+
+def collect_project_symbols(project_root: str | Path) -> list[dict]:
+    """Walk project_root for .py files and return symbol descriptors.
+
+    Excludes common noise dirs (``__pycache__``, ``node_modules``, venvs).
+    Silently skips files with syntax or encoding errors — collection
+    should never fail the whole reindex over one bad file.
+    """
+    root = Path(project_root).resolve()
+    if not root.is_dir():
+        return []
+    out: list[dict] = []
+    for py in root.rglob("*.py"):
+        if any(part in _EXCLUDE_DIRS for part in py.parts):
+            continue
+        out.extend(_iter_symbols_in_file(py, root))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Indexing — batched embed + upsert into symbols / symbol_vectors
+# ---------------------------------------------------------------------------
+
+
+def _embed_batch(docs: list[str]) -> list[list[float] | None]:
+    """Embed documents sequentially via the shared ``embed()`` helper.
+
+    Sequential calls are used instead of ``model.embed(docs)`` because
+    FastEmbed's ONNX backend holds onto intermediate buffers across a
+    materialised batch — a single ``list(model.embed(100_docs))`` spiked
+    this process past 3 GB RSS on 4 GB-available VPS and tripped the OOM
+    killer. One-at-a-time keeps the peak at ~500 MB (matches the
+    memory_retrieval bench measurements) at the cost of ~100 ms per
+    symbol on CPU, which is fine for a one-off reindex.
+    """
+    from token_savior.memory.embeddings import embed
+    return [embed(doc) for doc in docs]
+
+
+def _serialize_vec(vec: list[float]) -> Any | None:
+    try:
+        import sqlite_vec
+        return sqlite_vec.serialize_float32(vec)
+    except Exception:
+        return None
+
+
+def reindex_project_symbols(
+    project_root: str | Path,
+    *,
+    db_path: str | Path | None = None,
+    batch_size: int = _BATCH_SIZE,
+) -> dict[str, Any]:
+    """Collect, embed, and upsert all symbols in ``project_root``.
+
+    Fast path: a symbol whose ``content_hash`` already matches the stored
+    row is skipped (no re-embed). This makes re-running the indexer cheap
+    when only a handful of files changed.
+
+    Returns a summary dict:
+      * status     : "ok" | "unavailable"
+      * total      : symbols seen
+      * indexed    : symbols newly embedded and written
+      * skipped    : symbols whose hash was unchanged
+      * elapsed_s  : wall clock
+      * reason     : filled when status != "ok"
+    """
+    from token_savior import memory_db
+    from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
+    from token_savior.memory.embeddings import is_available
+
+    if not VECTOR_SEARCH_AVAILABLE:
+        return {"status": "unavailable", "reason": "sqlite-vec not loadable"}
+    if not is_available():
+        return {"status": "unavailable", "reason": "embedding model not loadable"}
+
+    t0 = time.perf_counter()
+    root_str = str(Path(project_root).resolve())
+    symbols = collect_project_symbols(root_str)
+    now_epoch = int(time.time())
+
+    indexed = 0
+    skipped = 0
+    to_embed: list[dict] = []
+
+    def conn_factory():
+        return memory_db.db_session(db_path) if db_path else memory_db.db_session()
+    with conn_factory() as conn:
+        existing = dict(conn.execute(
+            "SELECT symbol_key, content_hash FROM symbols WHERE project_root=?",
+            (root_str,),
+        ).fetchall())
+
+        for sym in symbols:
+            if existing.get(sym["symbol_key"]) == sym["content_hash"]:
+                skipped += 1
+                continue
+            to_embed.append(sym)
+
+        for i in range(0, len(to_embed), batch_size):
+            chunk = to_embed[i:i + batch_size]
+            vecs = _embed_batch([s["embed_doc"] for s in chunk])
+            for sym, vec in zip(chunk, vecs, strict=False):
+                if vec is None:
+                    continue
+                blob = _serialize_vec(vec)
+                if blob is None:
+                    continue
+                cur = conn.execute(
+                    "INSERT INTO symbols("
+                    "  project_root, symbol_key, file_path, lineno, kind,"
+                    "  signature, docstring_head, content_hash, updated_at_epoch"
+                    ") VALUES (?,?,?,?,?,?,?,?,?) "
+                    "ON CONFLICT(project_root, symbol_key) DO UPDATE SET "
+                    "  file_path=excluded.file_path,"
+                    "  lineno=excluded.lineno,"
+                    "  kind=excluded.kind,"
+                    "  signature=excluded.signature,"
+                    "  docstring_head=excluded.docstring_head,"
+                    "  content_hash=excluded.content_hash,"
+                    "  updated_at_epoch=excluded.updated_at_epoch "
+                    "RETURNING id",
+                    (
+                        sym["project_root"], sym["symbol_key"],
+                        sym["file_path"], sym["lineno"], sym["kind"],
+                        sym["signature"], sym["docstring_head"],
+                        sym["content_hash"], now_epoch,
+                    ),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    continue
+                symbol_id = row[0]
+                conn.execute(
+                    "INSERT OR REPLACE INTO symbol_vectors(symbol_id, embedding) "
+                    "VALUES (?, ?)",
+                    (symbol_id, blob),
+                )
+                indexed += 1
+        # Prune rows for symbols that vanished from the project tree.
+        live_keys = {s["symbol_key"] for s in symbols}
+        stale_keys = [k for k in existing if k not in live_keys]
+        removed = 0
+        for key in stale_keys:
+            cur = conn.execute(
+                "DELETE FROM symbols WHERE project_root=? AND symbol_key=? "
+                "RETURNING id",
+                (root_str, key),
+            )
+            row = cur.fetchone()
+            if row is not None:
+                conn.execute(
+                    "DELETE FROM symbol_vectors WHERE symbol_id=?", (row[0],),
+                )
+                removed += 1
+        conn.commit()
+
+    return {
+        "status": "ok",
+        "total": len(symbols),
+        "indexed": indexed,
+        "skipped": skipped,
+        "removed": removed,
+        "elapsed_s": round(time.perf_counter() - t0, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Query — k-NN over symbol_vectors with safety metadata
+# ---------------------------------------------------------------------------
+
+
+def search_symbols_semantic(
+    query: str,
+    project_root: str | Path,
+    *,
+    limit: int = 10,
+    db_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """k-NN over symbol_vectors for ``project_root``.
+
+    Returns ``{"status": str, "hits": [...], "warning": Optional[str]}``.
+    Each hit carries the disambiguation metadata required by the safety
+    contract (see docs/design-semantic-code-tools.md): signature,
+    docstring head, file:line, score.
+
+    Warnings:
+      * ``"low_confidence"`` when top1 score < 0.75 or when top1-top2
+        delta < 0.02 (dense cluster, likely ambiguous).
+    """
+    from token_savior import memory_db
+    from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
+    from token_savior.memory.embeddings import embed
+
+    if not VECTOR_SEARCH_AVAILABLE:
+        return {"status": "unavailable", "reason": "sqlite-vec not loadable", "hits": []}
+    qvec = embed(query, as_query=True)
+    if qvec is None:
+        return {"status": "unavailable", "reason": "query embed failed", "hits": []}
+    blob = _serialize_vec(qvec)
+    if blob is None:
+        return {"status": "unavailable", "reason": "vec serialize failed", "hits": []}
+
+    root_str = str(Path(project_root).resolve())
+    k = max(int(limit), 5)
+
+    sql = (
+        "SELECT s.symbol_key, s.file_path, s.lineno, s.kind, s.signature,"
+        "       s.docstring_head, v.distance "
+        "FROM symbol_vectors v "
+        "JOIN symbols s ON s.id = v.symbol_id "
+        "WHERE v.embedding MATCH ? AND k = ? AND s.project_root = ? "
+        "ORDER BY v.distance"
+    )
+    def conn_factory():
+        return memory_db.db_session(db_path) if db_path else memory_db.db_session()
+    with conn_factory() as conn:
+        rows = conn.execute(sql, (blob, k, root_str)).fetchall()
+
+    hits: list[dict] = []
+    for r in rows:
+        # sqlite-vec vec0 FLOAT[N] stores L2 distance by default. Our
+        # vectors are L2-normalised upstream, so the identity
+        #   |a - b|^2 = 2 - 2·(a·b)
+        # gives  cos(a, b) = 1 - L2^2 / 2  on the [-1, 1] interval.
+        l2 = float(r["distance"])
+        cos_score = max(0.0, 1.0 - (l2 * l2) / 2.0)
+        _, qname = r["symbol_key"].split("::", 1) if "::" in r["symbol_key"] else ("", r["symbol_key"])
+        hits.append({
+            "symbol": qname,
+            "kind": r["kind"],
+            "file": r["file_path"],
+            "line": r["lineno"],
+            "signature": r["signature"],
+            "docstring_head": r["docstring_head"],
+            "score": round(cos_score, 4),
+        })
+
+    warning: str | None = None
+    if hits:
+        top1 = hits[0]["score"]
+        top2 = hits[1]["score"] if len(hits) > 1 else 0.0
+        if top1 < 0.75 or (top1 - top2) < 0.02:
+            warning = (
+                f"low_confidence: top1={top1:.2f}, top2={top2:.2f}. "
+                "Consider refining the query or verifying via find_symbol."
+            )
+
+    return {
+        "status": "ok",
+        "hits": hits,
+        "warning": warning,
+    }

--- a/src/token_savior/query_api.py
+++ b/src/token_savior/query_api.py
@@ -2059,8 +2059,27 @@ class ProjectQueryEngine:
         min_lines: int = 2,
         max_groups: int = 30,
         max_members_per_group: int = 6,
+        method: str = "ast",
+        min_similarity: float = 0.90,
     ) -> str:
-        """Group functions whose AST-normalised hash collides.
+        """Group functions that do the same thing.
+
+        Two strategies:
+
+        * ``method="ast"`` (default, fast): group functions whose
+          AST-normalised hash collides. Catches copy-paste and minor
+          renames cleanly, misses conceptual clones rewritten from
+          scratch.
+        * ``method="embedding"`` (slower, requires Nomic stack):
+          rank every pair of functions by cosine similarity of their
+          embedding; emit clusters above ``min_similarity``. Catches
+          rewrites that AST hash can't see (reordered branches,
+          different variable names) but introduces false positives
+          around boilerplate — always cross-check via
+          ``get_function_source`` before merging. Reuses the
+          ``symbol_vectors`` index populated by
+          ``search_codebase(semantic=True)``; first call triggers a
+          reindex.
 
         *min_lines* skips trivial one-liner functions where collisions
         are noise (`return None`, getters, etc). Default 2 catches
@@ -2074,6 +2093,12 @@ class ProjectQueryEngine:
         clean 2-member clone is usually more actionable than a 20-way
         boilerplate cluster.
         """
+        if method == "embedding":
+            return self._find_semantic_duplicates_embedding(
+                min_similarity=min_similarity,
+                max_groups=max_groups,
+                max_members_per_group=max_members_per_group,
+            )
         if self._semantic_hash_cache is None:
             self._build_semantic_hash_cache(min_lines)
 
@@ -2099,6 +2124,151 @@ class ProjectQueryEngine:
                 lines.append(f"  hash {h}: {shown}, +{len(syms) - cap} more")
             else:
                 lines.append(f"  hash {h}: {', '.join(syms)}")
+        return "\n".join(lines)
+
+    def _find_semantic_duplicates_embedding(
+        self,
+        min_similarity: float,
+        max_groups: int,
+        max_members_per_group: int,
+    ) -> str:
+        """Embedding-based duplicate detection — clusters symbols whose
+        pairwise cosine similarity exceeds ``min_similarity``.
+
+        Uses a simple union-find over edges ``sim(a, b) >= threshold``
+        to collapse transitive clusters. On a 1000-symbol project the
+        pair enumeration is 500k comparisons; each is a cheap dot
+        product on normalised 768d vectors — runs in 1-2 seconds once
+        the index is warm. The real cost is the first-call reindex
+        (~2 min, same as ``search_codebase(semantic=True)``).
+        """
+        try:
+            from token_savior.memory.symbol_embeddings import (
+                reindex_project_symbols,
+            )
+            from token_savior import memory_db
+            import sqlite_vec  # noqa: F401  # loaded side-effect
+        except ImportError as exc:
+            return f"Semantic duplicates (embedding): unavailable ({exc})"
+
+        root = self.index.root_path
+        reindex = reindex_project_symbols(root)
+        if reindex.get("status") != "ok":
+            return (
+                "Semantic duplicates (embedding): unavailable "
+                f"({reindex.get('reason', 'unknown')})"
+            )
+
+        # Fetch every (symbol_id, symbol_key, embedding) for this project.
+        # sqlite-vec doesn't expose the raw float vector via the vec0 table
+        # once serialised, so we deserialise client-side.
+        import struct
+
+        with memory_db.db_session() as conn:
+            rows = conn.execute(
+                "SELECT s.id, s.symbol_key, s.kind, v.embedding "
+                "FROM symbols s JOIN symbol_vectors v ON v.symbol_id = s.id "
+                "WHERE s.project_root = ?",
+                (root,),
+            ).fetchall()
+
+        symbols: list[tuple[int, str, str, list[float]]] = []
+        for r in rows:
+            blob = bytes(r["embedding"])
+            if len(blob) % 4 != 0:
+                continue
+            n = len(blob) // 4
+            vec = list(struct.unpack(f"{n}f", blob))
+            symbols.append((r["id"], r["symbol_key"], r["kind"], vec))
+
+        # Collapse clusters via Union-Find: every edge whose cosine
+        # meets the threshold joins two nodes. For normalised vectors,
+        # cos(a, b) = dot(a, b).
+        parent = list(range(len(symbols)))
+
+        def _find(i: int) -> int:
+            while parent[i] != i:
+                parent[i] = parent[parent[i]]
+                i = parent[i]
+            return i
+
+        def _union(a: int, b: int) -> None:
+            ra, rb = _find(a), _find(b)
+            if ra != rb:
+                parent[ra] = rb
+
+        def _is_container_member_pair(a_key: str, b_key: str) -> bool:
+            """True when one symbol is a direct member of the other
+            (e.g. ``pkg/x.py::Foo`` vs ``pkg/x.py::Foo.__init__``). The
+            embeddings are naturally close because both share the class
+            name, but structurally they're not clones — skip.
+            """
+            if "::" not in a_key or "::" not in b_key:
+                return False
+            a_file, a_qname = a_key.split("::", 1)
+            b_file, b_qname = b_key.split("::", 1)
+            if a_file != b_file:
+                return False
+            if a_qname == b_qname:
+                return True
+            return (
+                b_qname.startswith(a_qname + ".")
+                or a_qname.startswith(b_qname + ".")
+            )
+
+        threshold = float(min_similarity)
+        pairs_checked = 0
+        skipped_container = 0
+        for i in range(len(symbols)):
+            vi = symbols[i][3]
+            key_i = symbols[i][1]
+            for j in range(i + 1, len(symbols)):
+                key_j = symbols[j][1]
+                if _is_container_member_pair(key_i, key_j):
+                    skipped_container += 1
+                    continue
+                vj = symbols[j][3]
+                dot = 0.0
+                for a, b in zip(vi, vj, strict=True):
+                    dot += a * b
+                pairs_checked += 1
+                if dot >= threshold:
+                    _union(i, j)
+
+        # Materialise clusters of size >= 2.
+        clusters: dict[int, list[str]] = {}
+        for i, (_, key, _, _) in enumerate(symbols):
+            root_id = _find(i)
+            clusters.setdefault(root_id, []).append(key)
+        groups = [
+            sorted(members) for members in clusters.values() if len(members) >= 2
+        ]
+        if not groups:
+            return (
+                f"Semantic duplicates (embedding, sim>={threshold:.2f}): "
+                f"none found across {len(symbols)} symbols "
+                f"({pairs_checked} pairs checked)."
+            )
+
+        # Pairs first, then larger clusters, as in the AST path.
+        groups.sort(key=lambda g: (0 if len(g) == 2 else 1, -len(g)))
+        total = len(groups)
+        groups = groups[:max_groups]
+
+        lines = [
+            f"Semantic duplicates (embedding, sim>={threshold:.2f}): "
+            f"{total} cluster(s) found across {len(symbols)} symbols "
+            f"(showing top {len(groups)})",
+            "WARNING: embedding matches can be conceptual but not functional."
+            " Verify with get_function_source before merging or deleting.",
+        ]
+        cap = max(2, max_members_per_group) if max_members_per_group > 0 else 0
+        for members in groups:
+            if cap and len(members) > cap:
+                shown = ", ".join(members[:cap])
+                lines.append(f"  cluster({len(members)}): {shown}, +{len(members) - cap} more")
+            else:
+                lines.append(f"  cluster({len(members)}): {', '.join(members)}")
         return "\n".join(lines)
 
     # ------------------------------------------------------------------

--- a/src/token_savior/query_api.py
+++ b/src/token_savior/query_api.py
@@ -1304,19 +1304,39 @@ class ProjectQueryEngine:
         max_results: int = 100,
         max_line_chars: int = 160,
         ignore_generated: bool = True,
+        semantic: bool = False,
     ) -> list[dict]:
-        """Regex across all files, returns [{file, line_number, content}].
+        """Regex (default) or semantic search across project files.
 
-        Each hit's `content` is truncated to `max_line_chars` (default 160,
-        suffixed with "…") so verbose matches like long comment lines don't
-        explode the response. Pass 0 to disable truncation.
+        Regex mode (``semantic=False``) returns ``[{file, line_number,
+        content}]``. Each hit's `content` is truncated to
+        ``max_line_chars`` (default 160, suffixed with "…"). Pass 0 to
+        disable truncation.
 
         ``ignore_generated`` (default True) filters out files that are
-        typically auto-generated or minified — ``*.generated.*``, ``*.min.*``,
-        ``*.pb.*``, ``*.proto``, ``dist/``, ``build/``, ``.next/``,
-        ``node_modules/`` — so Prisma/proto schema lookups don't drown in
-        boilerplate hits. Pass False to scan everything.
+        typically auto-generated or minified — ``*.generated.*``,
+        ``*.min.*``, ``*.pb.*``, ``*.proto``, ``dist/``, ``build/``,
+        ``.next/``, ``node_modules/`` — so Prisma/proto schema lookups
+        don't drown in boilerplate hits. Pass False to scan everything.
+
+        Semantic mode (``semantic=True``) treats ``pattern`` as a natural
+        language description and returns the top-K matching symbols
+        (Python functions/classes/methods) by embedding cosine similarity.
+        Each hit carries ``{symbol, kind, file, line, score, signature,
+        docstring_head}`` for disambiguation. A ``warning`` entry is
+        prepended when confidence is low (score < 0.75 or top1-top2 gap
+        < 0.02) — the caller should refine the query or fall back to
+        regex. **Never act on a semantic hit (call / edit / delete) without
+        verifying via ``find_symbol(exact_name)`` first** — semantic
+        near-misses are plausible by design.
+
+        First semantic call triggers a one-time embedding reindex of all
+        project symbols (~2 min for 1000 symbols on CPU). Subsequent calls
+        are fast (hash-based skip of unchanged symbols). Silent fallback
+        to an empty result list when the vector stack is unavailable.
         """
+        if semantic:
+            return self._search_codebase_semantic(pattern, max_results)
         from token_savior.project_indexer import is_path_excluded_from_scans
 
         try:
@@ -1381,6 +1401,54 @@ class ProjectQueryEngine:
                         if limit and len(results) >= limit:
                             return results
         return results
+
+    def _search_codebase_semantic(
+        self, pattern: str, max_results: int,
+    ) -> list[dict]:
+        """Semantic path of ``search_codebase``. Auto-reindexes symbols on
+        the first call per project, then runs a k-NN query. Returns a list
+        where the first item may be a ``{"warning": ...}`` dict followed
+        by hit dicts, mirroring the shape of the regex path (so both modes
+        stay uniform for JSON consumers).
+        """
+        try:
+            from token_savior.memory.symbol_embeddings import (
+                reindex_project_symbols,
+                search_symbols_semantic,
+            )
+        except ImportError as exc:
+            return [{"error": f"semantic search unavailable: {exc}"}]
+
+        root = self.index.root_path
+        limit = max(int(max_results), 5) if max_results else 10
+
+        reindex = reindex_project_symbols(root)
+        if reindex.get("status") != "ok":
+            return [{
+                "error": (
+                    f"semantic index unavailable: "
+                    f"{reindex.get('reason', 'unknown')}"
+                ),
+            }]
+
+        result = search_symbols_semantic(pattern, root, limit=limit)
+        if result.get("status") != "ok":
+            return [{"error": result.get("reason", "semantic search failed")}]
+
+        out: list[dict] = []
+        if result.get("warning"):
+            out.append({"warning": result["warning"]})
+        out.extend(result["hits"])
+        if reindex.get("indexed", 0) > 0 or reindex.get("removed", 0) > 0:
+            out.append({
+                "reindex_info": (
+                    f"indexed={reindex['indexed']} "
+                    f"skipped={reindex['skipped']} "
+                    f"removed={reindex['removed']} "
+                    f"elapsed_s={reindex['elapsed_s']}"
+                ),
+            })
+        return out
 
     def search_in_symbols(
         self,

--- a/src/token_savior/server_handlers/analysis.py
+++ b/src/token_savior/server_handlers/analysis.py
@@ -21,6 +21,7 @@ from token_savior.db_schema import get_db_schema as run_get_db_schema
 from token_savior.dead_code import find_dead_code as run_dead_code
 from token_savior.docker_analyzer import analyze_docker as run_docker_analysis
 from token_savior.library_api import (
+    find_library_symbol_by_description as run_find_library_symbol_by_description,
     get_library_symbol as run_get_library_symbol,
     list_library_symbols as run_list_library_symbols,
 )
@@ -257,6 +258,23 @@ def _h_list_library_symbols(slot: _ProjectSlot, args: dict) -> object:
     )
 
 
+def _h_find_library_symbol_by_description(slot: _ProjectSlot, args: dict) -> object:
+    package = args.get("package")
+    description = args.get("description")
+    if not package:
+        return {"ok": False, "error": "'package' is required"}
+    if not description:
+        return {"ok": False, "error": "'description' is required"}
+    return run_find_library_symbol_by_description(
+        package,
+        description,
+        project_root=slot.root,
+        limit=int(args.get("limit", 10)),
+        max_files=int(args.get("max_files", 100)),
+        candidate_pool=int(args.get("candidate_pool", 200)),
+    )
+
+
 HANDLERS: dict[str, Any] = {
     "analyze_config": _h_analyze_config,
     "find_dead_code": _h_find_dead_code,
@@ -268,4 +286,5 @@ HANDLERS: dict[str, Any] = {
     "get_db_schema": _h_get_db_schema,
     "get_library_symbol": _h_get_library_symbol,
     "list_library_symbols": _h_list_library_symbols,
+    "find_library_symbol_by_description": _h_find_library_symbol_by_description,
 }

--- a/src/token_savior/server_handlers/code_nav.py
+++ b/src/token_savior/server_handlers/code_nav.py
@@ -707,6 +707,8 @@ QFN_HANDLERS: dict[str, object] = {
     "find_semantic_duplicates": lambda q, a: q["find_semantic_duplicates"](
         min_lines=a.get("min_lines", 2),
         max_groups=a.get("max_groups", 10),
+        method=a.get("method", "ast"),
+        min_similarity=a.get("min_similarity", 0.90),
     ),
     "find_import_cycles": lambda q, a: q["find_import_cycles"](
         max_cycles=a.get("max_cycles", 20),

--- a/src/token_savior/server_handlers/code_nav.py
+++ b/src/token_savior/server_handlers/code_nav.py
@@ -677,6 +677,7 @@ QFN_HANDLERS: dict[str, object] = {
             a["pattern"],
             max_results=a.get("max_results", 100),
             ignore_generated=a.get("ignore_generated", True),
+            semantic=a.get("semantic", False),
         ),
         a["pattern"],
     ),

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -966,6 +966,47 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "required": ["package"],
         },
     },
+    "find_library_symbol_by_description": {
+        "description": (
+            "Rank a library's exports by embedding similarity to a "
+            "natural-language description. On-the-fly, no persistent "
+            "index — scans the package, embeds each export (Python gets "
+            "enriched with docstring + signature via inspect; TS uses "
+            "name + kind), cosine-ranks against the query. Returns top-K "
+            "with scores. "
+            "SAFETY — the same rule as search_codebase(semantic=True): "
+            "re-resolve by exact name via get_library_symbol before "
+            "acting on a hit. A `warning` is set when confidence is low "
+            "(top1 < 0.75 or top1-top2 gap < 0.02)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "package": {
+                    "type": "string",
+                    "description": "npm package name or Python module.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Natural-language description of what the symbol does.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Top-K hits to return (default 10).",
+                },
+                "max_files": {
+                    "type": "integer",
+                    "description": "Cap on .d.ts files scanned (default 100).",
+                },
+                "candidate_pool": {
+                    "type": "integer",
+                    "description": "Max exports considered before ranking (default 200).",
+                },
+                **_PROJECT_PARAM,
+            },
+            "required": ["package", "description"],
+        },
+    },
     "audit_file": {
         "description": (
             "Mega-batch audit of a single file: dead_code + hotspots + semantic "
@@ -1438,19 +1479,42 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "find_semantic_duplicates": {
         "description": (
-            "Find semantically identical functions across the codebase via "
-            "AST-normalised hashing (alpha-renaming, docstrings stripped)."
+            "Find duplicate functions across the codebase. Two methods: "
+            "method='ast' (default, fast) groups by AST-normalised hash "
+            "(alpha-renaming, docstrings stripped) — catches copy-paste and "
+            "renames, misses rewrites. method='embedding' clusters by "
+            "cosine similarity over Nomic symbol embeddings — catches "
+            "conceptual clones AST hash can't see, but introduces false "
+            "positives on boilerplate. Always verify via "
+            "get_function_source before merging or deleting."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "min_lines": {
                     "type": "integer",
-                    "description": "Skip functions shorter than this (default 2).",
+                    "description": "Skip functions shorter than this (default 2). Applies to method='ast'.",
                 },
                 "max_groups": {
                     "type": "integer",
                     "description": "Max duplicate groups to return (default 10). Raise for full audit.",
+                },
+                "method": {
+                    "type": "string",
+                    "enum": ["ast", "embedding"],
+                    "description": (
+                        "ast (default, fast, exact) or embedding (slower, "
+                        "catches conceptual clones). Embedding reuses the "
+                        "symbol_vectors index from search_codebase(semantic=True) "
+                        "— first call triggers a ~2min reindex."
+                    ),
+                },
+                "min_similarity": {
+                    "type": "number",
+                    "description": (
+                        "Cosine threshold for method='embedding' (default 0.90). "
+                        "Lower = more recall + more noise."
+                    ),
                 },
                 **_PROJECT_PARAM,
             },

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -575,16 +575,30 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "search_codebase": {
         "description": (
-            "Regex search across indexed files (100 matches max). Skips generated/minified "
-            "(ignore_generated=false to include). Symbol lookup: find_symbol. "
-            "Content + enclosing symbol: search_in_symbols."
+            "Regex (default) or semantic search across indexed files. "
+            "Regex mode returns {file, line_number, content}. "
+            "Semantic mode (semantic=true) treats `pattern` as a natural-"
+            "language description and returns top-K matching symbols by "
+            "embedding similarity with score + signature + docstring + "
+            "file:line for disambiguation. "
+            "SAFETY — never call, modify, or delete a symbol found only "
+            "by semantic match without re-resolving the exact name via "
+            "find_symbol first. Semantic near-misses (e.g. 'delete' "
+            "matching a query about 'dedup') are plausible by design; "
+            "always cross-check. A `warning` item is prepended when "
+            "confidence is low. "
+            "First semantic call per project triggers a ~2min one-off "
+            "embedding reindex; subsequent calls are fast."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "pattern": {
                     "type": "string",
-                    "description": "Regular expression pattern to search for.",
+                    "description": (
+                        "Regex pattern (regex mode) or natural-language "
+                        "description (semantic mode)."
+                    ),
                 },
                 "max_results": {
                     "type": "integer",
@@ -592,7 +606,16 @@ TOOL_SCHEMAS: dict[str, dict] = {
                 },
                 "ignore_generated": {
                     "type": "boolean",
-                    "description": "Skip generated/minified files (default true).",
+                    "description": "Skip generated/minified files (default true). Regex mode only.",
+                },
+                "semantic": {
+                    "type": "boolean",
+                    "description": (
+                        "If true, interpret `pattern` as a description and "
+                        "rank symbols by embedding cosine similarity. "
+                        "Returns enriched hits with signature/docstring/"
+                        "score. Default false (regex)."
+                    ),
                 },
                 **_PROJECT_PARAM,
             },

--- a/tests/benchmarks/code_retrieval/queries.json
+++ b/tests/benchmarks/code_retrieval/queries.json
@@ -1,0 +1,21 @@
+{
+  "_about": "Handcrafted retrieval queries against the token-savior codebase. Ground truth = list of symbol names that should appear in top-K of a semantic search. Queries deliberately avoid keyword overlap with the target symbol name to stress the semantic path.",
+  "_corpus_source": "/root/token-savior/src/token_savior/**/*.py",
+  "queries": [
+    {"id": "Q01", "query": "fuse two ranked lists of search results", "gt": ["rrf_merge"], "kind": "paraphrase"},
+    {"id": "Q02", "query": "merge results via reciprocal rank fusion", "gt": ["rrf_merge"], "kind": "paraphrase"},
+    {"id": "Q03", "query": "convert plain text into a dense vector embedding", "gt": ["embed"], "kind": "paraphrase"},
+    {"id": "Q04", "query": "detect strongly connected components in an import graph", "gt": ["find_import_cycles"], "kind": "paraphrase"},
+    {"id": "Q05", "query": "backfill missing vector rows for existing observations", "gt": ["backfill_obs_vectors"], "kind": "paraphrase"},
+    {"id": "Q06", "query": "deduplicate memory observations that are too similar", "gt": ["dedup_sweep"], "kind": "semantic-hard"},
+    {"id": "Q07", "query": "walk a project tree and enumerate all functions and classes", "gt": ["collect_project_symbols"], "kind": "paraphrase"},
+    {"id": "Q08", "query": "scan an FTS5 index with BM25 ranking", "gt": ["observation_search"], "kind": "semantic"},
+    {"id": "Q09", "query": "save a new memory observation to the database", "gt": ["observation_save"], "kind": "paraphrase"},
+    {"id": "Q10", "query": "load the embedding model only once", "gt": ["_load_model"], "kind": "semantic"},
+    {"id": "Q11", "query": "turn a numpy array into L2 normalised float list", "gt": ["_normalize_l2"], "kind": "paraphrase"},
+    {"id": "Q12", "query": "detect which tests are impacted by a change", "gt": ["find_impacted_test_files"], "kind": "semantic"},
+    {"id": "Q13", "query": "find duplicates via AST hash", "gt": ["find_semantic_duplicates"], "kind": "semantic"},
+    {"id": "Q14", "query": "list every file that imports a given file", "gt": ["get_file_dependents"], "kind": "paraphrase"},
+    {"id": "Q15", "query": "extract the shortest path between two symbols in the call graph", "gt": ["get_call_chain"], "kind": "paraphrase"}
+  ]
+}

--- a/tests/benchmarks/code_retrieval/results/20260423-001104.json
+++ b/tests/benchmarks/code_retrieval/results/20260423-001104.json
@@ -1,0 +1,243 @@
+{
+  "corpus_source": "/root/token-savior/src/token_savior",
+  "corpus_symbols": 999,
+  "indexed": 999,
+  "skipped": 0,
+  "index_seconds": 124.56,
+  "num_queries": 15,
+  "agg": {
+    "mrr_10": 0.7944,
+    "recall_3": 0.9333,
+    "recall_10": 1.0,
+    "p50_ms": 34.4,
+    "p95_ms": 82.1,
+    "low_confidence_rate": 0.87
+  },
+  "per_query": [
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q01",
+      "query": "fuse two ranked lists of search results",
+      "kind": "paraphrase",
+      "latency_ms": 32.93702192604542,
+      "low_confidence": true,
+      "top3": [
+        "rrf_merge",
+        "observation_search",
+        "get_relevance_cluster"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q02",
+      "query": "merge results via reciprocal rank fusion",
+      "kind": "paraphrase",
+      "latency_ms": 33.25128089636564,
+      "low_confidence": true,
+      "top3": [
+        "rrf_merge",
+        "observation_search",
+        "get_relevance_cluster"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q03",
+      "query": "convert plain text into a dense vector embedding",
+      "kind": "paraphrase",
+      "latency_ms": 39.1774398740381,
+      "low_confidence": true,
+      "top3": [
+        "embed",
+        "_mh_memory_vector_reindex",
+        "maybe_index_obs"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q04",
+      "query": "detect strongly connected components in an import graph",
+      "kind": "paraphrase",
+      "latency_ms": 43.52034907788038,
+      "low_confidence": false,
+      "top3": [
+        "find_import_cycles",
+        "_graph_based_test_candidates",
+        "_build_import_graph"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q05",
+      "query": "backfill missing vector rows for existing observations",
+      "kind": "paraphrase",
+      "latency_ms": 32.46970311738551,
+      "low_confidence": true,
+      "top3": [
+        "backfill_obs_vectors",
+        "_mh_memory_vector_reindex",
+        "observation_update"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q06",
+      "query": "deduplicate memory observations that are too similar",
+      "kind": "semantic-hard",
+      "latency_ms": 30.56463203392923,
+      "low_confidence": true,
+      "top3": [
+        "dedup_sweep",
+        "predict_next_ppm",
+        "global_dedup_check"
+      ]
+    },
+    {
+      "rr": 0.3333333333333333,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q07",
+      "query": "walk a project tree and enumerate all functions and classes",
+      "kind": "paraphrase",
+      "latency_ms": 34.39169004559517,
+      "low_confidence": true,
+      "top3": [
+        "get_env_usage",
+        "index",
+        "collect_project_symbols"
+      ]
+    },
+    {
+      "rr": 0.3333333333333333,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q08",
+      "query": "scan an FTS5 index with BM25 ranking",
+      "kind": "semantic",
+      "latency_ms": 30.849785078316927,
+      "low_confidence": true,
+      "top3": [
+        "_fts5_safe_query",
+        "get_recent_index",
+        "observation_search"
+      ]
+    },
+    {
+      "rr": 0.5,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q09",
+      "query": "save a new memory observation to the database",
+      "kind": "paraphrase",
+      "latency_ms": 32.95395500026643,
+      "low_confidence": true,
+      "top3": [
+        "_mh_memory_delete",
+        "observation_save",
+        "_mh_memory_restore"
+      ]
+    },
+    {
+      "rr": 0.5,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q10",
+      "query": "load the embedding model only once",
+      "kind": "semantic",
+      "latency_ms": 25.60191205702722,
+      "low_confidence": true,
+      "top3": [
+        "is_available",
+        "_load_model",
+        "embed"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q11",
+      "query": "turn a numpy array into L2 normalised float list",
+      "kind": "paraphrase",
+      "latency_ms": 39.11193087697029,
+      "low_confidence": false,
+      "top3": [
+        "_normalize_l2",
+        "_cosine",
+        "ASTNormalizer"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q12",
+      "query": "detect which tests are impacted by a change",
+      "kind": "semantic",
+      "latency_ms": 37.27145888842642,
+      "low_confidence": true,
+      "top3": [
+        "find_impacted_test_files",
+        "find_impacted_test_files",
+        "run_impacted_tests"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q13",
+      "query": "find duplicates via AST hash",
+      "kind": "semantic",
+      "latency_ms": 82.05539896152914,
+      "low_confidence": true,
+      "top3": [
+        "find_semantic_duplicates",
+        "check_duplicates",
+        "get_duplicate_classes"
+      ]
+    },
+    {
+      "rr": 0.25,
+      "recall_3": 0.0,
+      "recall_10": 1.0,
+      "id": "Q14",
+      "query": "list every file that imports a given file",
+      "kind": "paraphrase",
+      "latency_ms": 62.276525888592005,
+      "low_confidence": true,
+      "top3": [
+        "get_imports",
+        "_get_all_imports",
+        "_file_get_imports_impl"
+      ]
+    },
+    {
+      "rr": 1.0,
+      "recall_3": 1.0,
+      "recall_10": 1.0,
+      "id": "Q15",
+      "query": "extract the shortest path between two symbols in the call graph",
+      "kind": "paraphrase",
+      "latency_ms": 46.54855513945222,
+      "low_confidence": true,
+      "top3": [
+        "get_call_chain",
+        "get_full_context",
+        "_ts_lookup"
+      ]
+    }
+  ]
+}

--- a/tests/benchmarks/code_retrieval/results/20260423-001104.md
+++ b/tests/benchmarks/code_retrieval/results/20260423-001104.md
@@ -1,0 +1,32 @@
+# Code retrieval bench
+
+- Corpus: /root/token-savior/src/token_savior
+- Symbols: 999 (999 indexed)
+- Queries: 15 handcrafted with ground truth
+- Index time: 124.56s
+
+## Aggregate
+
+| MRR@10 | Recall@3 | Recall@10 | P50 ms | P95 ms | Low-conf rate |
+|---|---|---|---|---|---|
+| 0.7944 | 0.9333 | 1.0 | 34.4 | 82.1 | 0.87 |
+
+## Per-query
+
+| ID | Kind | RR | R@3 | Top-1 | Query |
+|---|---|---|---|---|---|
+| Q01 | paraphrase | 1.000 | 1.000 | `rrf_merge` ⚠️ | fuse two ranked lists of search results |
+| Q02 | paraphrase | 1.000 | 1.000 | `rrf_merge` ⚠️ | merge results via reciprocal rank fusion |
+| Q03 | paraphrase | 1.000 | 1.000 | `embed` ⚠️ | convert plain text into a dense vector embedding |
+| Q04 | paraphrase | 1.000 | 1.000 | `find_import_cycles` | detect strongly connected components in an import graph |
+| Q05 | paraphrase | 1.000 | 1.000 | `backfill_obs_vectors` ⚠️ | backfill missing vector rows for existing observations |
+| Q06 | semantic-hard | 1.000 | 1.000 | `dedup_sweep` ⚠️ | deduplicate memory observations that are too similar |
+| Q07 | paraphrase | 0.333 | 1.000 | `get_env_usage` ⚠️ | walk a project tree and enumerate all functions and classes |
+| Q08 | semantic | 0.333 | 1.000 | `_fts5_safe_query` ⚠️ | scan an FTS5 index with BM25 ranking |
+| Q09 | paraphrase | 0.500 | 1.000 | `_mh_memory_delete` ⚠️ | save a new memory observation to the database |
+| Q10 | semantic | 0.500 | 1.000 | `is_available` ⚠️ | load the embedding model only once |
+| Q11 | paraphrase | 1.000 | 1.000 | `_normalize_l2` | turn a numpy array into L2 normalised float list |
+| Q12 | semantic | 1.000 | 1.000 | `find_impacted_test_files` ⚠️ | detect which tests are impacted by a change |
+| Q13 | semantic | 1.000 | 1.000 | `find_semantic_duplicates` ⚠️ | find duplicates via AST hash |
+| Q14 | paraphrase | 0.250 | 0.000 | `get_imports` ⚠️ | list every file that imports a given file |
+| Q15 | paraphrase | 1.000 | 1.000 | `get_call_chain` ⚠️ | extract the shortest path between two symbols in the call graph |

--- a/tests/benchmarks/code_retrieval/run_bench.py
+++ b/tests/benchmarks/code_retrieval/run_bench.py
@@ -1,0 +1,166 @@
+"""Code retrieval bench: semantic search_codebase over the token-savior source.
+
+Builds a one-off symbol_vectors index for ``src/token_savior/``, replays
+``queries.json``, and reports MRR@10 / Recall@3 / Recall@10 plus the
+low-confidence warning rate. The result lands under ``results/`` for
+future comparison (re-run after a model change to spot regressions).
+
+Runs standalone (not pytest):
+    python tests/benchmarks/code_retrieval/run_bench.py
+"""
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+SRC = Path("/root/token-savior/src/token_savior")
+HERE = Path(__file__).resolve().parent
+QUERIES_PATH = HERE / "queries.json"
+RESULTS_DIR = HERE / "results"
+
+
+def _basename_from_key(key: str) -> str:
+    # symbol_key = "path/to/file.py::Qualified.Name"
+    if "::" not in key:
+        return key
+    _, qname = key.split("::", 1)
+    return qname.rsplit(".", 1)[-1]
+
+
+def _metrics(ranked_names: list[str], gt: list[str]) -> dict:
+    gt_set = set(gt)
+    # Deduplicate via ``set(...) & gt_set`` — when a symbol name exists
+    # in several files (eg. ``embed`` in multiple modules) the raw
+    # intersection would overcount and push Recall above 1.0.
+    hits_3 = len(set(ranked_names[:3]) & gt_set)
+    hits_10 = len(set(ranked_names[:10]) & gt_set)
+    rr = 0.0
+    for rank, n in enumerate(ranked_names[:10], 1):
+        if n in gt_set:
+            rr = 1.0 / rank
+            break
+    return {
+        "rr": rr,
+        "recall_3": hits_3 / len(gt_set) if gt_set else 0.0,
+        "recall_10": hits_10 / len(gt_set) if gt_set else 0.0,
+    }
+
+
+def _agg(per_query: list[dict]) -> dict:
+    if not per_query:
+        return {}
+    return {
+        "mrr_10": round(statistics.mean(r["rr"] for r in per_query), 4),
+        "recall_3": round(statistics.mean(r["recall_3"] for r in per_query), 4),
+        "recall_10": round(statistics.mean(r["recall_10"] for r in per_query), 4),
+        "p50_ms": round(statistics.median(r["latency_ms"] for r in per_query), 1),
+        "p95_ms": round(
+            statistics.quantiles(
+                [r["latency_ms"] for r in per_query], n=20
+            )[18], 1
+        ) if len(per_query) >= 20 else round(
+            max(r["latency_ms"] for r in per_query), 1
+        ),
+        "low_confidence_rate": round(
+            sum(1 for r in per_query if r["low_confidence"]) / len(per_query), 2
+        ),
+    }
+
+
+def run() -> dict:
+    sys.path.insert(0, "/root/token-savior/src")
+    from token_savior import db_core, memory_db
+    from token_savior.memory.symbol_embeddings import (
+        reindex_project_symbols, search_symbols_semantic,
+    )
+
+    qspec = json.loads(QUERIES_PATH.read_text())
+    queries = qspec["queries"]
+
+    with tempfile.TemporaryDirectory() as td:
+        db = Path(td) / "bench.db"
+        db_core.run_migrations(db)
+        memory_db.MEMORY_DB_PATH = str(db)
+
+        t0 = time.perf_counter()
+        reindex = reindex_project_symbols(SRC)
+        index_s = time.perf_counter() - t0
+        print(f"[bench] indexed {reindex['indexed']} symbols in {index_s:.1f}s",
+              flush=True)
+
+        per_query: list[dict] = []
+        for q in queries:
+            t = time.perf_counter()
+            res = search_symbols_semantic(q["query"], SRC, limit=10)
+            latency_ms = (time.perf_counter() - t) * 1000
+            names = [h["symbol"].rsplit(".", 1)[-1] for h in res["hits"]]
+            m = _metrics(names, q["gt"])
+            m["id"] = q["id"]
+            m["query"] = q["query"]
+            m["kind"] = q["kind"]
+            m["latency_ms"] = latency_ms
+            m["low_confidence"] = bool(res.get("warning"))
+            m["top3"] = names[:3]
+            per_query.append(m)
+
+    return {
+        "corpus_source": str(SRC),
+        "corpus_symbols": reindex.get("total", 0),
+        "indexed": reindex.get("indexed", 0),
+        "skipped": reindex.get("skipped", 0),
+        "index_seconds": round(index_s, 2),
+        "num_queries": len(queries),
+        "agg": _agg(per_query),
+        "per_query": per_query,
+    }
+
+
+def _report(result: dict) -> str:
+    agg = result["agg"]
+    lines = []
+    lines.append("# Code retrieval bench")
+    lines.append("")
+    lines.append(f"- Corpus: {result['corpus_source']}")
+    lines.append(f"- Symbols: {result['corpus_symbols']} ({result['indexed']} indexed)")
+    lines.append(f"- Queries: {result['num_queries']} handcrafted with ground truth")
+    lines.append(f"- Index time: {result['index_seconds']}s")
+    lines.append("")
+    lines.append("## Aggregate")
+    lines.append("")
+    lines.append("| MRR@10 | Recall@3 | Recall@10 | P50 ms | P95 ms | Low-conf rate |")
+    lines.append("|---|---|---|---|---|---|")
+    lines.append(
+        f"| {agg['mrr_10']} | {agg['recall_3']} | {agg['recall_10']} | "
+        f"{agg['p50_ms']} | {agg['p95_ms']} | {agg['low_confidence_rate']} |"
+    )
+    lines.append("")
+    lines.append("## Per-query")
+    lines.append("")
+    lines.append("| ID | Kind | RR | R@3 | Top-1 | Query |")
+    lines.append("|---|---|---|---|---|---|")
+    for r in result["per_query"]:
+        top1 = r["top3"][0] if r["top3"] else "—"
+        flag = " ⚠️" if r["low_confidence"] else ""
+        lines.append(
+            f"| {r['id']} | {r['kind']} | {r['rr']:.3f} | {r['recall_3']:.3f} | "
+            f"`{top1}`{flag} | {r['query']} |"
+        )
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    result = run()
+    md = _report(result)
+    print()
+    print(md)
+    RESULTS_DIR.mkdir(exist_ok=True)
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    (RESULTS_DIR / f"{stamp}.md").write_text(md, encoding="utf-8")
+    (RESULTS_DIR / f"{stamp}.json").write_text(
+        json.dumps(result, indent=2), encoding="utf-8",
+    )
+    print(f"\n[bench] wrote {RESULTS_DIR}/{stamp}.{{md,json}}")

--- a/tests/test_symbol_embeddings.py
+++ b/tests/test_symbol_embeddings.py
@@ -185,3 +185,42 @@ def test_reindex_prunes_deleted_symbols(fixture_project: Path, tmp_path: Path):
     second = reindex_project_symbols(fixture_project)
     assert second["removed"] == 3  # class + 2 methods
     assert second["total"] == 2
+
+
+@_VECTOR_REQUIRED
+def test_find_semantic_duplicates_embedding_filters_class_method_pairs(
+    fixture_project: Path, tmp_path: Path,
+):
+    """Feature 2 regression: at a realistic similarity threshold, a
+    class and its own method must not form a 2-element duplicate
+    cluster. The filter blocks the direct pair comparison; transitive
+    unions at very low thresholds are legitimate and not what this
+    guard is about.
+    """
+    from token_savior import db_core, memory_db
+    from token_savior.project_indexer import ProjectIndexer
+    from token_savior.query_api import ProjectQueryEngine
+
+    db = tmp_path / "bench.db"
+    db_core.run_migrations(db)
+    memory_db.MEMORY_DB_PATH = str(db)
+    idx = ProjectIndexer(str(fixture_project)).index()
+    engine = ProjectQueryEngine(idx)
+
+    report = engine.find_semantic_duplicates(
+        method="embedding", min_similarity=0.95, max_groups=30,
+    )
+    for line in report.splitlines():
+        if not line.startswith("  cluster(2)"):
+            continue
+        members = line.split(":", 1)[1]
+        # Parse the "a, b" into the two symbol keys. A cluster(2) pair
+        # where one ends with ".<member>" of the other is the exact
+        # failure mode the filter exists to prevent.
+        a, b = [m.strip() for m in members.split(",", 1)]
+        _, a_q = a.split("::", 1)
+        _, b_q = b.split("::", 1)
+        parent, child = sorted((a_q, b_q), key=len)
+        assert not child.startswith(parent + "."), (
+            f"class↔method pair slipped through: {line}"
+        )

--- a/tests/test_symbol_embeddings.py
+++ b/tests/test_symbol_embeddings.py
@@ -1,0 +1,187 @@
+"""Tests for memory/symbol_embeddings.py — the vector index over code
+symbols powering search_codebase(semantic=True).
+
+Covers:
+  * AST extraction produces one descriptor per function/class/method
+  * reindex_project_symbols upserts new symbols and skips unchanged ones
+  * stale symbols (file removed, renamed) are pruned on reindex
+  * search_symbols_semantic returns k>=5 hits with metadata
+  * low-confidence warning fires when top1 is weak or top1/top2 are close
+
+The tests mint a minimal Python fixture project in tmp_path to avoid
+pulling on the token-savior source tree (embedding 998 symbols would
+make the test suite unbearable). Embedding calls use the real Nomic
+model — skipped when the optional stack isn't installed.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _write(tmp_path: Path, rel: str, content: str) -> None:
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+@pytest.fixture
+def fixture_project(tmp_path: Path) -> Path:
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/ranker.py", '''
+        """Ranking helpers."""
+
+        def rank_results(candidates):
+            """Sort candidates by their score descending."""
+            return sorted(candidates, key=lambda c: c["score"], reverse=True)
+
+        def fuse_two_lists(a, b, k=60):
+            """Merge two ranked result lists via reciprocal rank fusion."""
+            scores = {}
+            for rows in (a, b):
+                for rank, item in enumerate(rows, 1):
+                    scores[item] = scores.get(item, 0) + 1 / (k + rank)
+            return sorted(scores, key=scores.get, reverse=True)
+    ''')
+    _write(tmp_path, "pkg/graph.py", '''
+        """Graph helpers."""
+
+        class ImportGraph:
+            """Directed graph over module imports."""
+
+            def find_cycles(self):
+                """Detect strongly-connected components (Tarjan)."""
+                return []
+
+            def add_edge(self, a, b):
+                """Record an import from a to b."""
+                pass
+    ''')
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# AST extraction
+# ---------------------------------------------------------------------------
+
+
+def test_collect_symbols_enumerates_functions_classes_methods(fixture_project: Path):
+    from token_savior.memory.symbol_embeddings import collect_project_symbols
+    syms = collect_project_symbols(fixture_project)
+    names = sorted(s["symbol_key"] for s in syms)
+    assert "pkg/ranker.py::rank_results" in names
+    assert "pkg/ranker.py::fuse_two_lists" in names
+    assert "pkg/graph.py::ImportGraph" in names
+    assert "pkg/graph.py::ImportGraph.find_cycles" in names
+    assert "pkg/graph.py::ImportGraph.add_edge" in names
+    assert len(syms) == 5
+
+
+def test_collect_symbols_skips_venv_and_pycache(tmp_path: Path):
+    from token_savior.memory.symbol_embeddings import collect_project_symbols
+    _write(tmp_path, "real/mod.py", "def keep_me(): pass\n")
+    _write(tmp_path, ".venv/lib/pkg.py", "def drop_me(): pass\n")
+    _write(tmp_path, "__pycache__/cached.py", "def drop_me_too(): pass\n")
+    keys = {s["symbol_key"] for s in collect_project_symbols(tmp_path)}
+    assert keys == {"real/mod.py::keep_me"}
+
+
+def test_collect_symbols_tolerates_syntax_errors(tmp_path: Path):
+    from token_savior.memory.symbol_embeddings import collect_project_symbols
+    _write(tmp_path, "ok.py", "def fine(): pass\n")
+    _write(tmp_path, "broken.py", "def oops( missing paren:\n")
+    keys = {s["symbol_key"] for s in collect_project_symbols(tmp_path)}
+    assert keys == {"ok.py::fine"}
+
+
+def test_symbol_descriptor_captures_signature_and_docstring(fixture_project: Path):
+    from token_savior.memory.symbol_embeddings import collect_project_symbols
+    syms = {s["symbol_key"]: s for s in collect_project_symbols(fixture_project)}
+    sym = syms["pkg/ranker.py::rank_results"]
+    assert sym["kind"] == "func"
+    assert sym["file_path"] == "pkg/ranker.py"
+    assert "def rank_results" in sym["signature"]
+    assert "Sort candidates" in sym["docstring_head"]
+    assert sym["content_hash"]
+
+
+# ---------------------------------------------------------------------------
+# Reindex + query (requires embedding stack)
+# ---------------------------------------------------------------------------
+
+
+def _vector_stack_ready() -> bool:
+    try:
+        from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
+        from token_savior.memory.embeddings import is_available
+        return bool(VECTOR_SEARCH_AVAILABLE and is_available())
+    except Exception:
+        return False
+
+
+_VECTOR_REQUIRED = pytest.mark.skipif(
+    not _vector_stack_ready(),
+    reason="sqlite-vec + fastembed not installed",
+)
+
+
+@_VECTOR_REQUIRED
+def test_reindex_then_search_finds_expected_symbol(fixture_project: Path, tmp_path: Path):
+    from token_savior import db_core, memory_db
+    from token_savior.memory.symbol_embeddings import (
+        reindex_project_symbols, search_symbols_semantic,
+    )
+
+    db = tmp_path / "bench.db"
+    db_core.run_migrations(db)
+    memory_db.MEMORY_DB_PATH = str(db)
+
+    summary = reindex_project_symbols(fixture_project)
+    assert summary["status"] == "ok"
+    assert summary["indexed"] == 5
+    assert summary["skipped"] == 0
+
+    res = search_symbols_semantic(
+        "merge two ranked lists using reciprocal rank fusion",
+        fixture_project, limit=5,
+    )
+    assert res["status"] == "ok"
+    assert res["hits"], "expected at least one hit"
+    assert res["hits"][0]["symbol"] == "fuse_two_lists"
+    # Every hit must carry the disambiguation metadata (safety contract).
+    for h in res["hits"]:
+        assert set(h) >= {"symbol", "kind", "file", "line", "signature", "docstring_head", "score"}
+
+
+@_VECTOR_REQUIRED
+def test_reindex_is_idempotent_on_unchanged_files(fixture_project: Path, tmp_path: Path):
+    from token_savior import db_core, memory_db
+    from token_savior.memory.symbol_embeddings import reindex_project_symbols
+
+    db = tmp_path / "bench.db"
+    db_core.run_migrations(db)
+    memory_db.MEMORY_DB_PATH = str(db)
+
+    first = reindex_project_symbols(fixture_project)
+    second = reindex_project_symbols(fixture_project)
+    assert first["indexed"] == 5
+    assert second["indexed"] == 0
+    assert second["skipped"] == 5
+
+
+@_VECTOR_REQUIRED
+def test_reindex_prunes_deleted_symbols(fixture_project: Path, tmp_path: Path):
+    from token_savior import db_core, memory_db
+    from token_savior.memory.symbol_embeddings import reindex_project_symbols
+
+    db = tmp_path / "bench.db"
+    db_core.run_migrations(db)
+    memory_db.MEMORY_DB_PATH = str(db)
+    reindex_project_symbols(fixture_project)
+
+    (fixture_project / "pkg" / "graph.py").unlink()
+    second = reindex_project_symbols(fixture_project)
+    assert second["removed"] == 3  # class + 2 methods
+    assert second["total"] == 2

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -60,7 +60,8 @@ class TestToolSchemas:
         # +1 get_db_schema (SQL migrations parser) = 91.
         # +1 get_library_symbol (.d.ts / Python stub lookup) = 92.
         # +1 list_library_symbols (package export list) = 93.
-        assert len(TOOL_SCHEMAS) == 93, f"Expected 93 tools, got {len(TOOL_SCHEMAS)}"
+        # +1 find_library_symbol_by_description (feature 3 — semantic library lookup) = 94.
+        assert len(TOOL_SCHEMAS) == 94, f"Expected 94 tools, got {len(TOOL_SCHEMAS)}"
 
     def test_server_tools_match_schemas(self):
         from token_savior.server import TOOLS


### PR DESCRIPTION
## Summary

Implements all three opportunities from `docs/design-semantic-code-tools.md` (shipped as the scaffolding PR #13). Every feature reuses the Nomic-v1.5-Q embedding stack already in production for memory search — no new model.

| # | Tool | Status |
|---|---|---|
| 1 | `search_codebase(semantic=True)` | ✅ shipped |
| 2 | `find_semantic_duplicates(method="embedding")` | ✅ shipped |
| 3 | `find_library_symbol_by_description` | ✅ shipped |

## Bench before / after

### Memory retrieval (unchanged — the memory path wasn't touched)

| Config | MRR@10 | Recall@3 | Recall@10 |
|---|---|---|---|
| fts5 | 0.789 | 0.892 | 0.925 |
| hybrid (Nomic) | **0.869** | 0.878 | 0.958 |

### Code retrieval (NEW bench, this PR)

15 handcrafted queries against the token-savior source (998 symbols).

| MRR@10 | Recall@3 | Recall@10 | P50 ms | P95 ms | Low-conf rate |
|---|---|---|---|---|---|
| **0.794** | 0.933 | 1.000 | 34 | 82 | 0.87 |

The low-confidence rate (87%) is expected and by design: code corpora are semantically denser than narrative memory (many functions are neighbours), so the safety warning fires often. Every hit carries `{symbol, kind, file, line, score, signature, docstring_head}` so the consumer can disambiguate without a second call.

## Safety contract (applies to all 3 features)

Semantic near-misses are plausible and can mislead — the POC showed `_mh_memory_delete` ranking #1 for a "remove duplicates" query, which would be catastrophic if auto-executed. Every feature enforces:

1. Always return top-K ≥ 5 with scores visible (no top-1-only).
2. Per-hit metadata to disambiguate without a second call.
3. `warning` payload when top1 < 0.75 or top1-top2 gap < 0.02.
4. MCP schema descriptions explicitly require re-resolution via `find_symbol(exact_name)` / `get_library_symbol(exact_name)` before any destructive operation.
5. No auto-edit path: `replace_symbol_source` / `move_symbol` / destructive ops take exact names only.

Documented in detail under `docs/design-semantic-code-tools.md → Safety design`.

## What's in

### Infrastructure
- `symbols` + `symbol_vectors USING vec0(FLOAT[768])` tables added in `db_core.py`. Migration is additive — no legacy to drop.
- `src/token_savior/memory/symbol_embeddings.py` (372 lines): AST walker, sequential batched embed (OOM-safe), L2→cosine conversion, content-hash idempotent reindex, stale-symbol pruning.

### Feature 1
- `search_codebase(semantic=True)` in `ProjectQueryEngine`. Auto-reindex on first call, k-NN query after.
- MCP schema + handler pass-through.

### Feature 2
- `find_semantic_duplicates(method="embedding", min_similarity=0.9)` on top of the existing AST-hash path. Union-find clustering, container-member pair filter.

### Feature 3
- `find_library_symbol_by_description` top-level in `library_api.py`. Python path gets docstring/signature enrichment via inspect; TS stays on name+kind.
- Full MCP wiring (tool schema, handler, dispatcher count 93 → 94).

### Tests + bench
- 8 tests in `tests/test_symbol_embeddings.py` (AST walker, reindex idempotency, stale pruning, class/method pair filter).
- New `tests/benchmarks/code_retrieval/` bench with 15 queries + ground truth, committed baseline result.
- Full pytest: **1357/1357 green**. Ruff clean.

## Test plan

- [x] All unit + integration tests pass
- [x] Ruff clean
- [x] Code retrieval bench result committed as baseline (re-run on future model changes detects regression)
- [x] Manual smoke test for each of the 3 features
- [ ] Post-merge: try the three tools interactively on another project to surface edge cases in the wild

🤖 Generated with [Claude Code](https://claude.com/claude-code)