### PR TITLE
fix(windows): normalize stored relative paths to POSIX (closes #18)

### DIFF
--- a/src/token_savior/memory/symbol_embeddings.py
+++ b/src/token_savior/memory/symbol_embeddings.py
@@ -55,7 +55,7 @@ def _iter_symbols_in_file(py_path: Path, project_root: Path) -> Iterable[dict]:
         tree = ast.parse(source)
     except (OSError, SyntaxError):
         return
-    rel_path = str(py_path.relative_to(project_root))
+    rel_path = py_path.relative_to(project_root).as_posix()
 
     def _visit(node: ast.AST, prefix: str = "") -> Iterable[dict]:
         for child in ast.iter_child_nodes(node):

--- a/src/token_savior/project_indexer.py
+++ b/src/token_savior/project_indexer.py
@@ -285,7 +285,7 @@ class ProjectIndexer:
         total_classes = 0
 
         def _annotate_file(fpath: str) -> tuple[str, StructuralMetadata, float] | None:
-            rel_path = os.path.relpath(fpath, self.root_path)
+            rel_path = os.path.relpath(fpath, self.root_path).replace(os.sep, "/")
             try:
                 mtime = os.path.getmtime(fpath)
                 source = self._read_file(fpath)
@@ -393,7 +393,7 @@ class ProjectIndexer:
             if os.path.isabs(file_path)
             else os.path.join(self.root_path, file_path)
         )
-        rel_path = os.path.relpath(abs_path, self.root_path)
+        rel_path = os.path.relpath(abs_path, self.root_path).replace(os.sep, "/")
 
         idx = self._project_index
 
@@ -529,7 +529,7 @@ class ProjectIndexer:
             if os.path.isabs(file_path)
             else os.path.join(self.root_path, file_path)
         )
-        rel_path = os.path.relpath(abs_path, self.root_path)
+        rel_path = os.path.relpath(abs_path, self.root_path).replace(os.sep, "/")
 
         idx = self._project_index
         old_metadata = idx.files.get(rel_path)


### PR DESCRIPTION
## Summary
- `os.path.relpath` returns paths with the native separator, so on Windows the index stored `src\core.py` while the import resolver constructed lookup candidates with `/`. Every lookup missed → `import_graph` stayed empty (Pattern 2 in #18). Same root cause for the assertion failures of pattern `assert 'src\\core.py' == 'src/core.py'` (Pattern 1).
- Fix: normalize relpath output to POSIX at the three sites that feed `ProjectIndex.files` keys (`project_indexer._annotate_file`, `update_file`, `remove_file`) and at `memory/symbol_embeddings._iter_symbols_in_file`.
- `.replace(os.sep, '/')` is a no-op on POSIX, so Linux/macOS behavior is unchanged.

## Test plan
- [x] Linux full suite: `1410 passed, 8 skipped` (no regression)
- [ ] Windows: should unblock the 31 failures across:
  - `tests/test_impacted_tests.py`
  - `tests/test_java_indexing.py`
  - `tests/test_project_indexer.py::TestImportGraph`
  - `tests/test_symbol_embeddings.py`
  - `tests/test_workflow_ops.py`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)