### PR TITLE
cleanup: trim manifest + gate memory + ruby optional dep

### DIFF
--- a/hooks/memory-session-start.sh
+++ b/hooks/memory-session-start.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 # Memory Engine — SessionStart hook
+#
+# TS_HOOK_MINIMAL=1     -> emit only the Memory Index block (skip Continuity,
+#                          Tool Capture status, Warm start, statusline, decay).
+# TS_MEMORY_DISABLE=1   -> short-circuit entirely (no output at all). Used by
+#                          tsbench subprocesses where cross-project memory
+#                          would pollute task context.
+
+if [ "$TS_MEMORY_DISABLE" = "1" ]; then
+    exit 0
+fi
 
 # -- token-savior hook error log (see GitHub #15) ---------------------------
 # Re-routes stderr from Python / claude sub-shells so a broken import, a
@@ -163,6 +173,13 @@ if project:
         db.commit()
     db.close()
 " 2>>"$ERR_LOG"
+fi
+
+# TS_HOOK_MINIMAL=1 short-circuit — skip warm-start, capture status,
+# statusline, and weekly housekeeping subshell. Memory Index + Continuity
+# already emitted above are kept.
+if [ "$TS_HOOK_MINIMAL" = "1" ]; then
+    exit 0
 fi
 
 # Warm start: find similar historical sessions by signature and pre-warm PPM

--- a/src/token_savior/ruby_annotator.py
+++ b/src/token_savior/ruby_annotator.py
@@ -1,9 +1,17 @@
-"""Tree-sitter-based Ruby annotator."""
+"""Tree-sitter-based Ruby annotator (optional — graceful fallback if deps missing)."""
 
 from __future__ import annotations
 
-import tree_sitter_ruby
-from tree_sitter import Language, Node, Parser
+try:
+    import tree_sitter_ruby
+    from tree_sitter import Language, Node, Parser
+    _RUBY_AVAILABLE = True
+    _RUBY_LANGUAGE = Language(tree_sitter_ruby.language())
+except ImportError:
+    _RUBY_AVAILABLE = False
+    _RUBY_LANGUAGE = None
+    Node = object  # type: ignore[assignment, misc]
+    Parser = None  # type: ignore[assignment, misc]
 
 from token_savior.models import (
     ClassInfo,
@@ -13,8 +21,6 @@ from token_savior.models import (
     StructuralMetadata,
     build_line_char_offsets,
 )
-
-_RUBY_LANGUAGE = Language(tree_sitter_ruby.language())
 
 _VISIBILITY_KEYWORDS = frozenset({"private", "protected", "public"})
 
@@ -389,11 +395,27 @@ def _parse_top_level(
 
 
 def annotate_ruby(source: str, source_name: str = "<source>") -> StructuralMetadata:
-    """Parse Ruby source and extract structural metadata using tree-sitter."""
+    """Parse Ruby source and extract structural metadata using tree-sitter.
+
+    Falls back to a generic empty annotation when tree_sitter_ruby is not
+    installed (optional dep). The Ruby support requires
+    `pip install tree_sitter_ruby tree_sitter`.
+    """
     lines = source.split("\n")
     total_lines = len(lines)
     total_chars = len(source)
     line_offsets = build_line_char_offsets(lines)
+    if not _RUBY_AVAILABLE:
+        return StructuralMetadata(
+            source_name=source_name,
+            total_lines=total_lines,
+            total_chars=total_chars,
+            lines=lines,
+            line_char_offsets=line_offsets,
+            functions=[],
+            classes=[],
+            imports=[],
+        )
     source_bytes = source.encode("utf-8")
 
     parser = Parser(_RUBY_LANGUAGE)

--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -149,6 +149,11 @@ _LEAN_EXCLUDES: set[str] = {
     # Niche analysis — edge cases, rare in practice
     "get_duplicate_classes", "get_call_predictions",
     "pack_context",
+    # Tool capture — agent never invokes capture_put/purge directly
+    # (hook handles that). capture_aggregate/list also rarely needed
+    # interactively. capture_get + capture_search stay visible so the
+    # agent can retrieve sandboxed outputs after compaction.
+    "capture_put", "capture_purge", "capture_aggregate", "capture_list",
     # (discover_project_actions + run_project_action kept atomically —
     #  low volume but paired workflow would break if split.)
 }
@@ -189,6 +194,24 @@ _HIDDEN_UNDER_ULTRA: set[str] = _PROFILE_EXCLUDES["ultra"]
 if _PROFILE != "full":
     _excluded = _PROFILE_EXCLUDES[_PROFILE]
     TOOLS = [t for t in TOOLS if t.name not in _excluded]
+
+# When memory is disabled at runtime (e.g. bench subprocess) hide the
+# remaining memory entrypoints from the manifest — every advertised tool
+# costs ~50-100 tokens whether it's used or not.
+if os.environ.get("TS_MEMORY_DISABLE") == "1":
+    _MEMORY_GATED = {
+        "memory_save", "memory_archive", "memory_set_global", "memory_mode",
+        "memory_index", "memory_search", "memory_get", "memory_top",
+        "memory_status", "memory_session_history", "memory_timeline",
+        "memory_prompts", "memory_doctor", "memory_consistency",
+        "memory_quarantine_list", "memory_maintain", "memory_distill",
+        "memory_dedup_sweep", "memory_roi_gc", "memory_roi_stats",
+        "memory_vector_reindex", "memory_delete", "memory_why",
+        "memory_bus_push", "memory_bus_list", "memory_from_bash",
+        "reasoning_save", "reasoning_search", "reasoning_list",
+        "corpus_build", "corpus_query",
+    }
+    TOOLS = [t for t in TOOLS if t.name not in _MEMORY_GATED]
 
 if _PROFILE == "ultra":
     _hidden_catalog = ", ".join(sorted(_HIDDEN_UNDER_ULTRA))

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -30,18 +30,12 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Meta tools ────────────────────────────────────────────────────────
     "list_projects": {
         "description": (
-        "List all registered workspace projects with index status.\n"
-        "USE WHEN: you need to pick a project name before switch_project.\n"
-        "NOT WHEN: you want the active project's overview — use get_project_summary."
-    ),
+        'List all registered workspace projects with index status.'   ),
         "inputSchema": {"type": "object", "properties": {}},
     },
     "switch_project": {
         "description": (
-        "Switch the active project.\n"
-        "USE WHEN: the user pivots to a different indexed codebase.\n"
-        "NOT WHEN: the project isn't registered yet — use set_project_root.\n"
-        "Subsequent tool calls without project= target the new active root."
+        'Switch the active project.'
     ),
         "inputSchema": {
             "type": "object",
@@ -57,18 +51,12 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Git & diff ────────────────────────────────────────────────────────
     "get_git_status": {
         "description": (
-        "Structured git status: branch, ahead/behind, staged, unstaged, untracked.\n"
-        "USE WHEN: pre-commit sanity check or diagnosing local repo state.\n"
-        "NOT WHEN: you need symbol-level changes, not file-level — use get_changed_symbols."
-    ),
+        'Structured git status: branch, ahead/behind, staged, unstaged, untracked.'   ),
         "inputSchema": {"type": "object", "properties": {**_PROJECT_PARAM}},
     },
     "get_changed_symbols": {
         "description": (
-        "Symbol-level summary of worktree changes (or HEAD vs ref).\n"
-        "USE WHEN: reviewing which functions/classes moved in a diff.\n"
-        "NOT WHEN: commit-message tasks — use build_commit_summary; scoped to specific file paths — use summarize_patch_by_symbol."
-    ),
+        'Symbol-level summary of worktree changes (or HEAD vs ref).' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -81,10 +69,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "summarize_patch_by_symbol": {
         "description": (
-        "Symbol-level summary of a specific set of changed files.\n"
-        "USE WHEN: reviewing a patch scoped to known file paths.\n"
-        "NOT WHEN: whole-worktree changes — use get_changed_symbols; commit message draft — use build_commit_summary."
-    ),
+        'Symbol-level summary of a specific set of changed files.' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -97,10 +82,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "build_commit_summary": {
         "description": (
-        "Compact commit/review narrative with stats, hotspots, suggested type.\n"
-        "USE WHEN: drafting a commit message or PR description.\n"
-        "NOT WHEN: you just need the diff symbol-level — use get_changed_symbols."
-    ),
+        'Compact commit/review narrative with stats, hotspots, suggested type.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -115,10 +97,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Checkpoints (unified) ─────────────────────────────────────────────
     "checkpoint": {
         "description": (
-        "Unified checkpoint CRUD. op = create | list (default) | restore | delete | prune | compare.\n"
-        "USE WHEN: snapshotting a bounded file set before risky edits, or diffing worktree vs a prior state.\n"
-        "NOT WHEN: you want git-based history — use git directly (checkpoints are separate from git)."
-    ),
+        'Unified checkpoint CRUD. op = create | list (default) | restore | delete | prune | compare.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -151,10 +130,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Structural edits ──────────────────────────────────────────────────
     "replace_symbol_source": {
         "description": (
-        "Replace an indexed symbol's full source block directly.\n"
-        "USE WHEN: rewriting a function/method/class body in place.\n"
-        "NOT WHEN: adding code near an existing symbol — use insert_near_symbol.\n"
-        "Triggers inline reindex, no manual reindex needed."
+        "Replace an indexed symbol's full source block directly."
     ),
         "inputSchema": {
             "type": "object",
@@ -178,10 +154,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "insert_near_symbol": {
         "description": (
-        "Insert content before or after an indexed symbol.\n"
-        "USE WHEN: adding a new function/import/decorator adjacent to an existing one.\n"
-        "NOT WHEN: replacing a symbol's body — use replace_symbol_source.\n"
-        "Triggers inline reindex."
+        'Insert content before or after an indexed symbol.'
     ),
         "inputSchema": {
             "type": "object",
@@ -197,10 +170,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "move_symbol": {
         "description": (
-        "Move a symbol to a different file, updating imports in all call sites.\n"
-        "USE WHEN: relocating a function/class and want the import graph fixed automatically.\n"
-        "NOT WHEN: in-place body rewrite — use replace_symbol_source; adding a field to a class — use add_field_to_model."
-    ),
+        'Move a symbol to a different file, updating imports in all call sites.' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -214,10 +184,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "add_field_to_model": {
         "description": (
-        "Add a field to a model/class/interface. Supports .prisma, .py (dataclass, SQLAlchemy), .ts/.tsx.\n"
-        "USE WHEN: extending a data model with a new typed field.\n"
-        "NOT WHEN: adding arbitrary code near a symbol — use insert_near_symbol."
-    ),
+        'Add a field to a model/class/interface. Supports .prisma, .py (dataclass, SQLAlchemy), .ts/.tsx.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -233,10 +200,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "apply_refactoring": {
         "description": (
-        "Polymorphic refactoring: rename, move, add_field, extract.\n"
-        "USE WHEN: cross-file rename with import fixup; moving a symbol; adding a model field; extracting a block into a new function.\n"
-        "NOT WHEN: rewriting one function body in place — use replace_symbol_source."
-    ),
+        'Polymorphic refactoring: rename, move, add_field, extract.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -264,10 +228,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Tests & validation ────────────────────────────────────────────────
     "find_impacted_test_files": {
         "description": (
-        "Infer pytest files likely impacted by changed files or symbols.\n"
-        "USE WHEN: narrowing which tests to run after an edit.\n"
-        "NOT WHEN: you want to actually run them — use run_impacted_tests (calls this internally)."
-    ),
+        'Infer pytest files likely impacted by changed files or symbols.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -280,10 +241,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "run_impacted_tests": {
         "description": (
-        "Run pytest on files impacted by the current worktree changes.\n"
-        "USE WHEN: quick regression check after an edit, scoped to impacted tests only.\n"
-        "NOT WHEN: you want the list only (no execution) — use find_impacted_test_files."
-    ),
+        'Run pytest on files impacted by the current worktree changes.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -300,10 +258,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "apply_symbol_change_and_validate": {
         "description": (
-        "Replace symbol source, reindex, run impacted tests in one call.\n"
-        "USE WHEN: committing a symbol rewrite and wanting automatic test-gated safety.\n"
-        "NOT WHEN: pre-change static safety check only — use verify_edit (no execution)."
-    ),
+        'Replace symbol source, reindex, run impacted tests in one call.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -324,18 +279,12 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Project actions ───────────────────────────────────────────────────
     "discover_project_actions": {
         "description": (
-        "Detect conventional project actions from build files (tests, lint, build, run) without executing.\n"
-        "USE WHEN: discovering what commands are available in an unfamiliar project.\n"
-        "NOT WHEN: you already know the action id and want to run it — use run_project_action."
-    ),
+        'Detect conventional project actions from build files (tests, lint, build, run) without executing.'   ),
         "inputSchema": {"type": "object", "properties": {**_PROJECT_PARAM}},
     },
     "run_project_action": {
         "description": (
-        "Run a discovered project action by id (bounded output, bounded timeout).\n"
-        "USE WHEN: executing a lint/test/build action returned by discover_project_actions.\n"
-        "NOT WHEN: you don't know the action id yet — use discover_project_actions first."
-    ),
+        'Run a discovered project action by id (bounded output, bounded timeout).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -351,18 +300,12 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Query tools ───────────────────────────────────────────────────────
     "get_project_summary": {
         "description": (
-        "Project overview: file count, packages, top classes/functions, infra dirs.\n"
-        "USE WHEN: getting your bearings on an unfamiliar project at session start.\n"
-        "NOT WHEN: you need per-file structure — use get_structure_summary."
-    ),
+        'Project overview: file count, packages, top classes/functions, infra dirs.'   ),
         "inputSchema": {"type": "object", "properties": {**_PROJECT_PARAM}},
     },
     "list_files": {
         "description": (
-        "List indexed files, optionally filtered by glob.\n"
-        "USE WHEN: confirming which files are in scope, or hunting a file by name pattern.\n"
-        "NOT WHEN: you know the file and want its structure — use get_structure_summary."
-    ),
+        'List indexed files, optionally filtered by glob.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -380,10 +323,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_structure_summary": {
         "description": (
-        "Structure of one file (functions, classes, imports, line counts), or project-wide if file omitted.\n"
-        "USE WHEN: quick table-of-contents of a file before drilling in.\n"
-        "NOT WHEN: you want a cross-project overview — use get_project_summary."
-    ),
+        'Structure of one file (functions, classes, imports, line counts), or project-wide if file omitted.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -397,10 +337,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_function_source": {
         "description": (
-        "Fetch a function/method source body.\n"
-        "USE WHEN: you need to read the code of a specific named function.\n"
-        "NOT WHEN: you want function + callers + deps in one shot — use get_full_context."
-    ),
+        'Fetch a function/method source body.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -417,10 +354,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_class_source": {
         "description": (
-        "Fetch a class source body (including methods).\n"
-        "USE WHEN: you need to read a specific named class's definition.\n"
-        "NOT WHEN: you want class + callers + deps together — use get_full_context.\n"
-        "Auto-downgrades to level 2 past 300 lines."
+        'Fetch a class source body (including methods).'
     ),
         "inputSchema": {
             "type": "object",
@@ -438,10 +372,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_functions": {
         "description": (
-        "List functions in a file (file_path=...) or across the project.\n"
-        "USE WHEN: enumerating what's where — file-wide or project-wide inventory.\n"
-        "NOT WHEN: you know the function name — use find_symbol (cheaper, exact)."
-    ),
+        'List functions in a file (file_path=...) or across the project.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -455,10 +386,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_classes": {
         "description": (
-        "List classes (name, lines, methods, bases, file).\n"
-        "USE WHEN: file-wide or project-wide class inventory.\n"
-        "NOT WHEN: you know the class name — use find_symbol (cheaper, exact)."
-    ),
+        'List classes (name, lines, methods, bases, file).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -472,10 +400,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_imports": {
         "description": (
-        "List imports (module, names, line).\n"
-        "USE WHEN: auditing what a file/project pulls in.\n"
-        "NOT WHEN: you want the reverse direction (who imports X) — use get_file_dependents."
-    ),
+        'List imports (module, names, line).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -491,10 +416,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "find_symbol": {
         "description": (
-        "Locate a symbol: file, line, signature, minimal preview.\n"
-        "USE WHEN: you know the name and need its location.\n"
-        "NOT WHEN: you also need source + deps — use get_full_context instead."
-    ),
+        'Locate a symbol: file, line, signature, minimal preview.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -514,10 +436,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_dependencies": {
         "description": (
-        "Outgoing deps of a symbol: what X calls/uses (downstream).\n"
-        "USE WHEN: tracing a call chain X → Y → Z (depth > 1 walks it in one call).\n"
-        "NOT WHEN: incoming (who-calls-X) — use get_dependents; transitive blast radius — use get_change_impact."
-    ),
+        'Outgoing deps of a symbol: what X calls/uses (downstream).' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -532,10 +451,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_dependents": {
         "description": (
-        "Incoming deps: who calls/uses X, direct references only.\n"
-        "USE WHEN: finding direct callers of a function/class (depth 1).\n"
-        "NOT WHEN: outgoing (what X calls) — use get_dependencies; transitive impact — use get_change_impact."
-    ),
+        'Incoming deps: who calls/uses X, direct references only.' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -550,10 +466,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_change_impact": {
         "description": (
-        "Impact analysis: direct + transitive dependents of a symbol.\n"
-        "USE WHEN: estimating risk before a rename, delete, or refactor (depth ≥ 2).\n"
-        "NOT WHEN: depth 1 who-calls-X — use get_dependents; outgoing (what X calls) — use get_dependencies."
-    ),
+        'Impact analysis: direct + transitive dependents of a symbol.' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -568,10 +481,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_full_context": {
         "description": (
-        "Symbol bundle: location + source + deps/dependents (depth=1) or + change_impact (depth=2).\n"
-        "USE WHEN: first-read of an unfamiliar symbol, holistic understanding in one call.\n"
-        "NOT WHEN: just the body — use get_function_source / get_class_source; pre-edit safety with siblings + tests — use get_edit_context."
-    ),
+        'Symbol bundle: location + source + deps/dependents (depth=1) or + change_impact (depth=2).' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -595,10 +505,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_call_chain": {
         "description": (
-        "Shortest dependency path between two symbols (BFS through the dep graph).\n"
-        "USE WHEN: proving connectivity A → ... → B, or finding the chain that links them.\n"
-        "NOT WHEN: direct neighbors only — use get_dependencies / get_dependents."
-    ),
+        'Shortest dependency path between two symbols (BFS through the dep graph).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -623,10 +530,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_edit_context": {
         "description": (
-        "Pre-edit bundle: source + direct deps + callers + same-file siblings + impacted tests.\n"
-        "USE WHEN: about to modify a symbol and want adjacent context upfront.\n"
-        "NOT WHEN: just understanding (no edit planned) — use get_full_context; file-wide audit — use audit_file."
-    ),
+        'Pre-edit bundle: source + direct deps + callers + same-file siblings + impacted tests.' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -640,10 +544,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_file_dependencies": {
         "description": (
-        "Files imported by this file (outgoing file-level import edges).\n"
-        "USE WHEN: \"what does module X depend on at file level\".\n"
-        "NOT WHEN: reverse direction (who imports X) — use get_file_dependents."
-    ),
+        'Files imported by this file (outgoing file-level import edges).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -662,10 +563,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_file_dependents": {
         "description": (
-        "Files that import this file (incoming file-level import edges).\n"
-        "USE WHEN: \"who depends on module X\" — cheaper than search_codebase('import X').\n"
-        "NOT WHEN: outgoing (what X imports) — use get_file_dependencies."
-    ),
+        'Files that import this file (incoming file-level import edges).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -684,10 +582,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "search_codebase": {
         "description": (
-        "Regex (default) or semantic (semantic=true) search across indexed files.\n"
-        "USE WHEN: regex for exact pattern/literal strings. Semantic for NL descriptions when you don't know the name.\n"
-        "NOT WHEN: you already know the symbol name — use find_symbol (cheaper).\n"
-        "SAFETY: semantic hits are leads, not answers; re-resolve via find_symbol before acting. First semantic call triggers ~2min reindex."
+        'Regex (default) or semantic (semantic=true) search across indexed files.'
     ),
         "inputSchema": {
             "type": "object",
@@ -723,10 +618,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "search_in_symbols": {
         "description": (
-        "Regex search that returns the enclosing function/class for each match, in addition to file:line.\n"
-        "USE WHEN: the next step is \"read the containing symbol\" — the `symbol` field plugs into get_function_source / get_class_source.\n"
-        "NOT WHEN: plain file-line hits are enough — use search_codebase (cheaper)."
-    ),
+        'Regex search that returns the enclosing function/class for each match, in addition to file:line.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -746,10 +638,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Index management ──────────────────────────────────────────────────
     "reindex": {
         "description": (
-        "Rebuild the project index.\n"
-        "USE WHEN: a file was edited outside TS tools (via your editor, sed, git pull) and you want the new state indexed.\n"
-        "NOT WHEN: you just used replace_symbol_source / insert_near_symbol — those reindex inline."
-    ),
+        'Rebuild the project index.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -763,10 +652,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "set_project_root": {
         "description": (
-        "Register a new project root and switch to it.\n"
-        "USE WHEN: the user opens a project that isn't in WORKSPACE_ROOTS yet.\n"
-        "NOT WHEN: the project is already registered — use switch_project.\n"
-        "Triggers a full reindex of the new root."
+        'Register a new project root and switch to it.'
     ),
         "inputSchema": {
             "type": "object",
@@ -782,10 +668,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Feature discovery ─────────────────────────────────────────────────
     "get_feature_files": {
         "description": (
-        "Files matching a feature keyword + traced imports, classified by role (core, test, config).\n"
-        "USE WHEN: locating all files touching a feature before diving in.\n"
-        "NOT WHEN: plain glob filtering — use list_files (cheaper)."
-    ),
+        'Files matching a feature keyword + traced imports, classified by role (core, test, config).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -799,10 +682,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Stats (unified) ───────────────────────────────────────────────────
     "get_stats": {
         "description": (
-        "Unified stats dispatcher. category = usage (default) | session_budget | tca | dcp | linucb | warmstart | leiden | speculation | lattice.\n"
-        "USE WHEN: inspecting a specific subsystem's internal state.\n"
-        "NOT WHEN: overall project health check — use get_project_summary (code) or memory_doctor (memory, full profile).\n"
-        "usage = session efficiency & chars saved; others = per-subsystem diagnostics."
+        'Unified stats dispatcher. category = usage (default) | session_budget | tca | dcp | linucb | warmstart | leiden | speculation | lattice.'
     ),
         "inputSchema": {
             "type": "object",
@@ -830,10 +710,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Routes, Env, Components ───────────────────────────────────────────
     "get_routes": {
         "description": (
-        "Detect API routes and pages in a Next.js App Router project: path, file, HTTP methods, type.\n"
-        "USE WHEN: mapping the HTTP surface of a Next.js project.\n"
-        "NOT WHEN: CLI/main entry points — use get_entry_points; non-Next frameworks aren't covered here."
-    ),
+        'Detect API routes and pages in a Next.js App Router project: path, file, HTTP methods, type.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -847,10 +724,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_env_usage": {
         "description": (
-        "Cross-reference an env var across code, .env files, and workflow configs. Shows where it's defined, read, written.\n"
-        "USE WHEN: auditing an env var's lifecycle before renaming or removing it.\n"
-        "NOT WHEN: bulk orphan detection — use analyze_config(checks=['orphans'])."
-    ),
+        "Cross-reference an env var across code, .env files, and workflow configs. Shows where it's defined, read, written."   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -869,10 +743,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_components": {
         "description": (
-        "Detect React components in .tsx/.jsx: pages, layouts, named (uppercase) and default exports.\n"
-        "USE WHEN: inventorying UI surface of a React/Next project.\n"
-        "NOT WHEN: generic class or function listing — use get_classes / get_functions."
-    ),
+        'Detect React components in .tsx/.jsx: pages, layouts, named (uppercase) and default exports.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -891,10 +762,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Analysis tools ────────────────────────────────────────────────────
     "analyze_config": {
         "description": (
-        "Audit config files (.env/.yaml/.toml/.json): duplicates, secrets, orphans.\n"
-        "USE WHEN: pre-deploy sanity check, or after touching .env to catch orphaned vars.\n"
-        "NOT WHEN: you need raw file content — use your client's file-read tool.\n"
-        "checks=['orphans'] = cheapest single-check mode."
+        'Audit config files (.env/.yaml/.toml/.json): duplicates, secrets, orphans.'
     ),
         "inputSchema": {
             "type": "object",
@@ -913,10 +781,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "find_dead_code": {
         "description": (
-        "Project-wide audit of unreferenced functions/classes (zero callers, excludes entry points, tests, route handlers).\n"
-        "USE WHEN: pre-release cleanup or refactor scoping.\n"
-        "NOT WHEN: file-scoped audit — use audit_file (batches dead_code + hotspots + duplicates); just list a file's functions — use get_functions."
-    ),
+        'Project-wide audit of unreferenced functions/classes (zero callers, excludes entry points, tests, route handlers).' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -930,10 +795,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "find_hotspots": {
         "description": (
-        "Rank functions by hotspot kind. complexity (all langs) | allocation (Java) | performance (Java).\n"
-        "USE WHEN: picking refactor targets across a project.\n"
-        "NOT WHEN: scoped to one file — use audit_file (batches dead_code + hotspots + duplicates).\n"
-        "T0-T3 tiers rank actionability. min_score default 0 for complexity, 1 for Java kinds."
+        'Rank functions by hotspot kind. complexity (all langs) | allocation (Java) | performance (Java).'
     ),
         "inputSchema": {
             "type": "object",
@@ -957,11 +819,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "detect_breaking_changes": {
         "description": (
-        "Breaking API changes vs a git ref: removed funcs/params, added required params, signature changes.\n"
-        "USE WHEN: pre-merge / pre-release gate to catch caller-breaking edits.\n"
-        "NOT WHEN: you want a plain symbol-level diff — use get_changed_symbols.\n"
-        "TERMINAL — output is complete; do not re-explore each item."
-    ),
+        'Breaking API changes vs a git ref: removed funcs/params, added required params, signature changes.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -975,10 +833,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "find_cross_project_deps": {
         "description": (
-        "Dependencies between indexed projects: which project imports packages from other indexed projects.\n"
-        "USE WHEN: understanding reach across a multi-repo workspace.\n"
-        "NOT WHEN: within one project — use get_file_dependents."
-    ),
+        'Dependencies between indexed projects: which project imports packages from other indexed projects.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {},
@@ -986,10 +841,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "analyze_docker": {
         "description": (
-        "Audit Dockerfiles: base images, stages, exposed ports, ENV/ARG, cross-ref with config files.\n"
-        "USE WHEN: pre-deploy Docker review. Flags 'latest' tags and missing env vars.\n"
-        "NOT WHEN: non-Dockerfile config audit — use analyze_config."
-    ),
+        'Audit Dockerfiles: base images, stages, exposed ports, ENV/ARG, cross-ref with config files.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -999,10 +851,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_db_schema": {
         "description": (
-        "Condensed SQL-migration snapshot: tables (cols, types, nullability, defaults), PKs, FKs, indexes, RLS policies.\n"
-        "USE WHEN: writing queries against a Supabase/Postgres-like schema — avoids re-reading raw .sql each time.\n"
-        "NOT WHEN: you need raw migration history — use your client's file-read tool.\n"
-        "Auto-detects supabase/migrations, migrations/, db/migrations/, prisma/migrations/."
+        'Condensed SQL-migration snapshot: tables (cols, types, nullability, defaults), PKs, FKs, indexes, RLS policies.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1026,10 +875,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_library_symbol": {
         "description": (
-        "Resolve a library symbol (npm .d.ts or Python module): signature, JSDoc/docstring, source location.\n"
-        "USE WHEN: checking the installed version's exact signature — beats Context7/doc fetches, ~100 tokens.\n"
-        "NOT WHEN: you don't know the exact name — use find_library_symbol_by_description (NL) or list_library_symbols (regex).\n"
-        "For dotted paths, pass the full chain (e.g. 'SupabaseAuthClient.signInWithOtp')."
+        'Resolve a library symbol (npm .d.ts or Python module): signature, JSDoc/docstring, source location.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1053,10 +899,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "list_library_symbols": {
         "description": (
-        "List top-level exports of an installed library (.d.ts or Python module), optionally regex-filtered.\n"
-        "USE WHEN: you know roughly what you want but not the exact name, and regex is enough.\n"
-        "NOT WHEN: NL description without regex — use find_library_symbol_by_description; exact name known — use get_library_symbol."
-    ),
+        'List top-level exports of an installed library (.d.ts or Python module), optionally regex-filtered.' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1083,10 +926,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "find_library_symbol_by_description": {
         "description": (
-        "Rank a package's exports by Nomic-embedding similarity to a NL description. On-the-fly, no persistent index.\n"
-        "USE WHEN: you don't know the exact name of a library export you need.\n"
-        "NOT WHEN: you know the name — use get_library_symbol (exact); regex-filtered enum is enough — use list_library_symbols.\n"
-        "SAFETY: re-resolve via get_library_symbol before acting. No low-confidence warning (scores don't discriminate on short docs)."
+        "Rank a package's exports by Nomic-embedding similarity to a NL description. On-the-fly, no persistent index."
     ),
         "inputSchema": {
             "type": "object",
@@ -1118,10 +958,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "audit_file": {
         "description": (
-        "Mega-batch audit of a single file: dead_code + hotspots + semantic duplicates in one call.\n"
-        "USE WHEN: triaging or reviewing a specific file before touching it.\n"
-        "NOT WHEN: project-wide hotspot ranking — use find_hotspots."
-    ),
+        'Mega-batch audit of a single file: dead_code + hotspots + semantic duplicates in one call.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1138,10 +975,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_entry_points": {
         "description": (
-        "Score functions by likelihood of being execution entry points: routes, handlers, main, exported APIs.\n"
-        "USE WHEN: understanding a project's entry surface during onboarding.\n"
-        "NOT WHEN: HTTP routes specifically in Next.js — use get_routes; React UI — use get_components."
-    ),
+        'Score functions by likelihood of being execution entry points: routes, handlers, main, exported APIs.' ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1155,10 +989,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_related_symbols": {
         "description": (
-        "Related-symbols query. method = community | rwr | cluster | coactive.\n"
-        "USE WHEN: finding symbols adjacent to X via graph or access patterns (beyond direct deps).\n"
-        "NOT WHEN: direct deps only — use get_dependencies / get_dependents; call path A→B — use get_call_chain.\n"
-        "community=Leiden; rwr=random-walk-with-restart; cluster=greedy modularity; coactive=TCA co-access."
+        'Related-symbols query. method = community | rwr | cluster | coactive.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1210,10 +1041,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_duplicate_classes": {
         "description": (
-        "Find Java classes duplicated across files (by FQN or simple name).\n"
-        "USE WHEN: Java-specific class-level dedup scan.\n"
-        "NOT WHEN: generic function/class dedup across any language — use find_semantic_duplicates (AST or embedding)."
-    ),
+        'Find Java classes duplicated across files (by FQN or simple name).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1227,10 +1055,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Memory Engine tools ───────────────────────────────────────────────
     "memory_save": {
         "description": (
-        "Persist a fact, guardrail, or note across sessions.\n"
-        "USE WHEN: the user says \"remember this\" or a finding is non-obvious from code.\n"
-        "NOT WHEN: auto-capture via PostToolUse hooks already covers it (bash, WebFetch).\n"
-        "Types: note, command, infra, guardrail, warning. Scope project_root by default."
+        'Persist a fact, guardrail, or note across sessions.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1276,8 +1101,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_maintain": {
         "description": (
-        "Maintenance rollup: promote, relink, export, extract patterns.\n"
-        "USE WHEN: periodic memory housekeeping (weekly or pre-distillation)."
+        'Maintenance rollup: promote, relink, export, extract patterns.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1294,8 +1118,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_top": {
         "description": (
-        "Rank observations by score, access_count, or age.\n"
-        "USE WHEN: auditing what's most-touched or oldest in the store."
+        'Rank observations by score, access_count, or age.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1307,8 +1130,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_why": {
         "description": (
-        "Explain why a specific observation matched the last injection (recency, type, symbol, FTS).\n"
-        "USE WHEN: debugging why a memory did or didn't surface."
+        'Explain why a specific observation matched the last injection (recency, type, symbol, FTS).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1321,16 +1143,12 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_doctor": {
         "description": (
-        "Memory health report: orphans, near-dupes, incomplete obs, vector coverage, hook wiring.\n"
-        "USE WHEN: diagnosing why auto-injection / recall is flaky or silent.\n"
-        "NOT WHEN: generic tool-usage stats — use get_stats."
-    ),
+        'Memory health report: orphans, near-dupes, incomplete obs, vector coverage, hook wiring.'   ),
         "inputSchema": {"type": "object", "properties": {}},
     },
     "memory_vector_reindex": {
         "description": (
-        "Backfill obs_vectors for observations missing an embedding. No-op if sqlite-vec/fastembed unavailable.\n"
-        "USE WHEN: after enabling the vector extra, or post-corruption recovery of the vec table."
+        'Backfill obs_vectors for observations missing an embedding. No-op if sqlite-vec/fastembed unavailable.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1342,8 +1160,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_distill": {
         "description": (
-        "MDL-based distillation: cluster similar obs into an abstraction + deltas.\n"
-        "USE WHEN: compressing N near-equivalent obs into one canonical + diffs."
+        'MDL-based distillation: cluster similar obs into an abstraction + deltas.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1357,8 +1174,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_dedup_sweep": {
         "description": (
-        "Backfill observations.content_hash (SHA256 of normalized content). Default: only NULL hashes.\n"
-        "USE WHEN: after a hash-formula change (recompute=true) or one-off backfill of old obs."
+        'Backfill observations.content_hash (SHA256 of normalized content). Default: only NULL hashes.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1371,8 +1187,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_roi_gc": {
         "description": (
-        "Archive observations whose ROI score falls below a threshold.\n"
-        "USE WHEN: periodic cleanup pass to prune low-utility memories."
+        'Archive observations whose ROI score falls below a threshold.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1385,8 +1200,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_roi_stats": {
         "description": (
-        "Token Economy ROI stats — net value by observation type.\n"
-        "USE WHEN: measuring which observation types pay for their token cost."
+        'Token Economy ROI stats — net value by observation type.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1395,10 +1209,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_from_bash": {
         "description": (
-        "Save a bash command as an observation (type=command, auto-extracted).\n"
-        "USE WHEN: manual capture of a shell command worth remembering.\n"
-        "NOT WHEN: generic fact/note capture — use memory_save (more flexible schema)."
-    ),
+        'Save a bash command as an observation (type=command, auto-extracted).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1412,8 +1223,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_set_global": {
         "description": (
-        "Set an observation's global visibility flag (is_global=True crosses all projects).\n"
-        "USE WHEN: promoting a project-scoped obs to cross-project (e.g. a VPS-wide convention)."
+        "Set an observation's global visibility flag (is_global=True crosses all projects)."
     ),
         "inputSchema": {
             "type": "object",
@@ -1426,10 +1236,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_search": {
         "description": (
-        "Layer 2 FTS5 search over memory observations, compact rows with snippets (~60 tokens/result).\n"
-        "USE WHEN: finding prior memories relevant to the current task.\n"
-        "NOT WHEN: the user wants to persist a new fact — use memory_save (write path, lean default)."
-    ),
+        'Layer 2 FTS5 search over memory observations, compact rows with snippets (~60 tokens/result).'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1443,8 +1250,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_session_history": {
         "description": (
-        "Last N structured session-end rollups (request, investigated, learned, completed, next_steps, notes).\n"
-        "USE WHEN: catching up on what happened in recent sessions on this project."
+        'Last N structured session-end rollups (request, investigated, learned, completed, next_steps, notes).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1456,8 +1262,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_get": {
         "description": (
-        "Layer 3: full observation content by IDs (~200 tokens/result). Final progressive-disclosure layer.\n"
-        "USE WHEN: reading the full body of an observation surfaced by memory_search or memory_index."
+        'Layer 3: full observation content by IDs (~200 tokens/result). Final progressive-disclosure layer.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1481,8 +1286,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_delete": {
         "description": (
-        "Soft-delete an observation by ID (sets archived=1).\n"
-        "USE WHEN: removing a specific obs confirmed wrong or obsolete."
+        'Soft-delete an observation by ID (sets archived=1).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1498,9 +1302,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_index": {
         "description": (
-        "Layer 1: compact index of recent observations — ID, type, title, importance, age, citation URI.\n"
-        "USE WHEN: cheapest memory exploration — always start here before drilling deeper."
-    ),
+        'Layer 1: compact index of recent observations — ID, type, title, importance, age, citation URI.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1519,8 +1321,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_timeline": {
         "description": (
-        "Chronological context around an observation (before/after in time).\n"
-        "USE WHEN: reconstructing the temporal sequence that produced an obs."
+        'Chronological context around an observation (before/after in time).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1540,8 +1341,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_prompts": {
         "description": (
-        "Save or search prompt history (archival of notable user prompts).\n"
-        "USE WHEN: pinning the current prompt or retrieving a past one."
+        'Save or search prompt history (archival of notable user prompts).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1558,8 +1358,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_mode": {
         "description": (
-        "Get or set the memory capture mode (code | review | debug | infra | silent).\n"
-        "USE WHEN: switching the session's capture aggressiveness."
+        'Get or set the memory capture mode (code | review | debug | infra | silent).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1573,8 +1372,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "corpus_build": {
         "description": (
-        "Build a thematic corpus from observations filtered by type / tags / symbol.\n"
-        "USE WHEN: assembling a focused knowledge slice for downstream Q&A."
+        'Build a thematic corpus from observations filtered by type / tags / symbol.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1590,8 +1388,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_archive": {
         "description": (
-        "Manage archived observations (list, undelete, purge).\n"
-        "USE WHEN: recovering a soft-deleted obs or cleaning dead archives."
+        'Manage archived observations (list, undelete, purge).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1607,8 +1404,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_status": {
         "description": (
-        "Memory Engine snapshot: active/archived counts, mode, last session, summaries.\n"
-        "USE WHEN: quick state check of the memory store at session start."
+        'Memory Engine snapshot: active/archived counts, mode, last session, summaries.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1618,10 +1414,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     # ── Program slicing & context packing (Phase 2) ───────────────────────
     "verify_edit": {
         "description": (
-        "EditSafety certificate — static analysis before a symbol replacement: signature, exceptions, side-effects, test impact.\n"
-        "USE WHEN: gating a destructive edit with cheap static checks.\n"
-        "NOT WHEN: you want execution-level validation — use apply_symbol_change_and_validate."
-    ),
+        'EditSafety certificate — static analysis before a symbol replacement: signature, exceptions, side-effects, test impact.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1644,10 +1437,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "find_semantic_duplicates": {
         "description": (
-        "Find duplicate functions. method='ast' (fast, hash-based, catches copy-paste) or 'embedding' (Nomic cosine, catches conceptual clones, tagged sim=min..mean per cluster).\n"
-        "USE WHEN: scoping a dedup or consolidation pass across the project.\n"
-        "NOT WHEN: file-scoped audit — use audit_file (batches dead_code + hotspots + duplicates).\n"
-        "SAFETY: always verify via get_function_source before merging; embedding matches can be conceptual not functional."
+        "Find duplicate functions. method='ast' (fast, hash-based, catches copy-paste) or 'embedding' (Nomic cosine, catches conceptual clones, tagged sim=min..mean per cluster)."
     ),
         "inputSchema": {
             "type": "object",
@@ -1683,10 +1473,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "find_import_cycles": {
         "description": (
-        "Detect import cycles (strongly-connected components) in the file-level import graph (Tarjan's).\n"
-        "USE WHEN: debugging a circular-import error or preparing a module reorg.\n"
-        "NOT WHEN: you want neighbors of one file — use get_file_dependencies / get_file_dependents."
-    ),
+        "Detect import cycles (strongly-connected components) in the file-level import graph (Tarjan's)."   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1700,8 +1487,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_call_predictions": {
         "description": (
-        "Predict next-likely tool calls from a first-order Markov model trained on prior sessions.\n"
-        "USE WHEN: inspecting what the prefetcher thinks you'll do next."
+        'Predict next-likely tool calls from a first-order Markov model trained on prior sessions.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1724,10 +1510,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "pack_context": {
         "description": (
-        "Knapsack-packed context bundle for a query within a token budget.\n"
-        "USE WHEN: manual token-budget assembly for a complex handoff prompt.\n"
-        "NOT WHEN: standard symbol lookup with deps — use get_full_context."
-    ),
+        'Knapsack-packed context bundle for a query within a token budget.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1741,10 +1524,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "get_backward_slice": {
         "description": (
-        "Minimal lines affecting a variable at a given line inside a symbol.\n"
-        "USE WHEN: extracting the causal slice behind one value for debugging.\n"
-        "NOT WHEN: you want callers of the enclosing symbol — use get_dependents."
-    ),
+        'Minimal lines affecting a variable at a given line inside a symbol.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1759,8 +1539,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "corpus_query": {
         "description": (
-        "Format all observations of a named corpus as markdown context + a question, ready for answering.\n"
-        "USE WHEN: asking a question over a pre-built corpus (after corpus_build)."
+        'Format all observations of a named corpus as markdown context + a question, ready for answering.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1780,8 +1559,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_bus_push": {
         "description": (
-        "Push a volatile observation to the inter-agent memory bus (tagged by agent_id).\n"
-        "USE WHEN: publishing a live note to peer agents without persisting to the main store."
+        'Push a volatile observation to the inter-agent memory bus (tagged by agent_id).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1801,8 +1579,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_bus_list": {
         "description": (
-        "List recent live messages on the inter-agent memory bus, optionally filtered by agent_id.\n"
-        "USE WHEN: reading peer-agent signals during a multi-agent task."
+        'List recent live messages on the inter-agent memory bus, optionally filtered by agent_id.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1816,8 +1593,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "reasoning_save": {
         "description": (
-        "Persist a reasoning trace (goal + steps + conclusion) for later reuse.\n"
-        "USE WHEN: capturing a multi-step analysis you expect to repeat."
+        'Persist a reasoning trace (goal + steps + conclusion) for later reuse.'
     ),
         "inputSchema": {
             "type": "object",
@@ -1835,8 +1611,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "reasoning_search": {
         "description": (
-        "Search stored reasoning chains by goal similarity (FTS5 + Jaccard).\n"
-        "USE WHEN: checking if you've already reasoned about a similar goal in a prior session."
+        'Search stored reasoning chains by goal similarity (FTS5 + Jaccard).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1854,9 +1629,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "reasoning_list": {
         "description": (
-        "List stored reasoning chains by access_count then recency.\n"
-        "USE WHEN: enumerating all past reasoning — pick one before reasoning_search for targeted lookup."
-    ),
+        'List stored reasoning chains by access_count then recency.'   ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1867,8 +1640,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_consistency": {
         "description": (
-        "Run Bayesian self-consistency check on symbol-linked obs (updates α/β; flags stale + quarantine).\n"
-        "USE WHEN: periodic sweep to flag obs that reference now-invalid symbols."
+        'Run Bayesian self-consistency check on symbol-linked obs (updates α/β; flags stale + quarantine).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1890,8 +1662,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     "memory_quarantine_list": {
         "description": (
-        "List observations quarantined by the consistency check (Bayesian validity < 40 %).\n"
-        "USE WHEN: reviewing obs the consistency sweep flagged as suspect."
+        'List observations quarantined by the consistency check (Bayesian validity < 40 %).'
     ),
         "inputSchema": {
             "type": "object",
@@ -1909,11 +1680,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
     },
     # ── Tool Capture (sandbox of verbose tool outputs) ───────────────────
     "capture_put": {
-        "description": (
-            "Persist a tool output (Bash, WebFetch, Playwright, gh api, MCP) outside context.\n"
-            "USE WHEN: a hook or an explicit caller wants to stash a >8KB output and only return a preview to the model.\n"
-            "NOT WHEN: the output is small enough (<2KB) that holding it in context costs nothing."
-        ),
+        "description": 'Sandbox a verbose tool output to FTS5 store; returns id + preview.',
         "inputSchema": {
             "type": "object",
             "required": ["tool_name", "output"],
@@ -1928,11 +1695,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
         },
     },
     "capture_search": {
-        "description": (
-            "BM25 search across captured tool outputs. Returns rows with id, snippet, bytes, age.\n"
-            "USE WHEN: the agent needs to find which capture holds a specific token (URL, error, identifier).\n"
-            "NOT WHEN: it already knows the capture id — use capture_get directly."
-        ),
+        "description": 'BM25 search across sandboxed tool outputs. Returns id, snippet, bytes.',
         "inputSchema": {
             "type": "object",
             "required": ["query"],
@@ -1946,11 +1709,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
         },
     },
     "capture_get": {
-        "description": (
-            "Fetch a captured output, optionally sliced (head/tail/all/preview/line:start-end).\n"
-            "USE WHEN: you need the actual content of a known capture id.\n"
-            "NOT WHEN: stats or counts are enough — use capture_aggregate (cheaper)."
-        ),
+        "description": 'Read a capture (range: head/tail/all/preview/line:N-M).',
         "inputSchema": {
             "type": "object",
             "required": ["id"],
@@ -1962,10 +1721,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
         },
     },
     "capture_aggregate": {
-        "description": (
-            "Aggregate over a capture without dumping it: stats, count_lines, unique_lines, extract:<re>, count:<re>.\n"
-            "USE WHEN: you only need a count, distinct values, or summary stats — saves loading the full output."
-        ),
+        "description": 'Aggregate over a capture: stats|count_lines|unique_lines|extract:<re>|count:<re>.',
         "inputSchema": {
             "type": "object",
             "required": ["id"],
@@ -1977,10 +1733,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
         },
     },
     "capture_list": {
-        "description": (
-            "List recent captures, newest first.\n"
-            "USE WHEN: you want to enumerate what's been sandboxed in this session."
-        ),
+        "description": 'List recent captures (newest first).',
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1992,10 +1745,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
         },
     },
     "capture_purge": {
-        "description": (
-            "Delete captures older than N seconds, or for a session/project.\n"
-            "USE WHEN: cleaning up after a session or trimming the capture store."
-        ),
+        "description": 'Delete captures by age/session/project (filter required).',
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/tests/test_markup_ruby.py
+++ b/tests/test_markup_ruby.py
@@ -1,6 +1,13 @@
 """Tests for the tree-sitter-based Ruby annotator."""
 
-from token_savior.ruby_annotator import annotate_ruby
+import pytest
+
+from token_savior.ruby_annotator import _RUBY_AVAILABLE, annotate_ruby
+
+pytestmark = pytest.mark.skipif(
+    not _RUBY_AVAILABLE,
+    reason="tree_sitter_ruby not installed (optional dep)",
+)
 
 
 SOURCE_BASIC = """\


### PR DESCRIPTION
## Summary

Reverses the +3.8k-token manifest bloat introduced by v2.8.1 USE WHEN / NOT WHEN rewrite, gates memory tools behind `TS_MEMORY_DISABLE` so bench subprocesses don't pay for hidden surface, and makes `tree_sitter_ruby` optional so contributors without the dep don't see 43 hard test failures.

## Manifest sizes (measured 2026-04-25)

| Profile | Tools | ~Tokens |
|---|---:|---:|
| full | 100 | 13 174 |
| full + `TS_MEMORY_DISABLE=1` | 69 | 9 583 |
| lean | 63 | 9 062 |
| **lean + `TS_MEMORY_DISABLE=1` (bench actual)** | **62** | **8 750** |
| ultra | 18 | 2 997 |

vs pre-trim lean ~12 615 tokens, saves **~3.9k tokens** on every bench task.

## What changed

### `tool_schemas.py` — first-line descriptions only (-13.6k chars)

v2.8.1 expanded every tool description to a 3-4 line USE WHEN / NOT WHEN / SAFETY block. Per-call cost ~+2.1k tokens on lean manifest with no measurable agent-quality gain. Reverted via AST rewrite to the leading sentence only.

The 6 `capture_*` schemas tightened in the same pass: 1 182 -> 365 chars.

### `server.py` — `TS_MEMORY_DISABLE` gate + capture excludes in lean

- When `TS_MEMORY_DISABLE=1` the manifest now hides `memory_*`, `reasoning_*`, `corpus_*` (~28 entries) instead of just silencing handlers. Bench subprocesses already set this env var, so they finally get the manifest savings.
- `_LEAN_EXCLUDES` adds `capture_put` / `capture_purge` / `capture_aggregate` / `capture_list`. The hook is the only realistic `capture_put` caller; the agent only needs `capture_get` / `capture_search` to retrieve.

### `ruby_annotator.py` — optional `tree_sitter_ruby`

PR #17 added Ruby support but the import was unconditional, so contributors without `pip install tree_sitter_ruby tree_sitter` got 43 hard test failures and a server boot crash. Wrapped the import in `try/except`, set `_RUBY_AVAILABLE`, fall back to empty `StructuralMetadata` when missing, gate `test_markup_ruby.py` with `pytest.mark.skipif`. `tree-sitter-ruby` remains a hard dep in `pyproject.toml`; the change just protects the local-dev experience.

## Tests

- 1 391 passed, 54 skipped (43 ruby + 11 pre-existing), 0 failed.

## Why this matters

The 25/04 bench (Run B Opus + TS) showed +172% active_tokens/task vs 21/04 baseline, with score going 180/180 -> 179/180. Telegram-bot diagnosis isolated it to v2.8.1 USE WHEN rewrite + capture_* manifest entries + bench `SYSTEM_PROMPT_TS` (separately addressed in tsbench repo). This PR closes the manifest side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)