### PR TITLE
fixes(operational): TS tool failure modes + edit_lines_in_symbol + lean expansion

### DIFF
--- a/src/token_savior/edit_ops.py
+++ b/src/token_savior/edit_ops.py
@@ -44,6 +44,93 @@ def replace_symbol_source(
     }
 
 
+def edit_lines_in_symbol(
+    index: ProjectIndex,
+    symbol_name: str,
+    old_string: str,
+    new_string: str,
+    file_path: str | None = None,
+    replace_all: bool = False,
+) -> dict:
+    """Exact string-replace inside an indexed symbol's body.
+
+    Adresses the most common pattern in real workflows: small in-place
+    edits (rename a variable, fix a typo, change a literal). Currently
+    the agent does Read+Edit for these because ``replace_symbol_source``
+    requires rewriting the whole symbol body. This wrapper lets the agent
+    stay symbol-scoped while editing line-level content.
+
+    The match is performed against the symbol's CURRENT source (resolved
+    via the index). If ``old_string`` is not found inside the symbol body
+    we return an error rather than touch unrelated lines elsewhere in the
+    file. If ``old_string`` appears more than once and ``replace_all`` is
+    False we error too — the agent has to disambiguate by extending the
+    context (same contract as the native Edit tool).
+    """
+    location = resolve_symbol_location(index, symbol_name, file_path=file_path)
+    if "error" in location:
+        return location
+
+    target_file = os.path.normpath(os.path.join(index.root_path, location["file"]))
+    if os.path.commonpath([target_file, os.path.normpath(index.root_path)]) != os.path.normpath(
+        index.root_path
+    ):
+        return {"error": f"Unsafe file path: {location['file']}"}
+
+    try:
+        with open(target_file, "r", encoding="utf-8") as fh:
+            content = fh.read()
+    except OSError as exc:
+        return {"error": f"failed to read {target_file}: {exc}"}
+
+    lines = content.split("\n")
+    start = location["line"] - 1  # 1-indexed -> 0-indexed
+    end = location["end_line"]
+    body = "\n".join(lines[start:end])
+
+    occurrences = body.count(old_string)
+    if occurrences == 0:
+        return {
+            "error": (
+                f"old_string not found in body of '{location['name']}' "
+                f"({target_file}:{location['line']}-{location['end_line']})."
+            ),
+            "hint": (
+                "Check exact whitespace + indentation. The match is "
+                "scoped to this symbol only; edits elsewhere in the file "
+                "need a different symbol or insert_near_symbol."
+            ),
+        }
+    if occurrences > 1 and not replace_all:
+        return {
+            "error": (
+                f"old_string appears {occurrences}x in '{location['name']}'. "
+                "Pass replace_all=True or extend old_string to make it unique."
+            ),
+        }
+
+    new_body = body.replace(old_string, new_string) if replace_all else body.replace(old_string, new_string, 1)
+    new_lines = new_body.split("\n")
+    rewrite = lines[:start] + new_lines + lines[end:]
+    new_content = "\n".join(rewrite)
+
+    try:
+        with open(target_file, "w", encoding="utf-8") as fh:
+            fh.write(new_content)
+    except OSError as exc:
+        return {"error": f"failed to write {target_file}: {exc}"}
+
+    return {
+        "ok": True,
+        "operation": "edit_lines_in_symbol",
+        "symbol": location["name"],
+        "type": location["type"],
+        "file": location["file"],
+        "occurrences_replaced": occurrences if replace_all else 1,
+        "delta_lines": len(new_lines) - (end - start),
+    }
+
+
 def insert_near_symbol(
     index: ProjectIndex,
     symbol_name: str,

--- a/src/token_savior/query_api.py
+++ b/src/token_savior/query_api.py
@@ -873,12 +873,15 @@ class ProjectQueryEngine:
     def get_functions(self, file_path: str | None = None, max_results: int = 100) -> list[dict]:
         """Functions in a file, or all functions across the project.
 
-        Default cap: 100 rows. A project-wide call on a ~2 500-function repo
-        without a cap returned 56 k tokens of JSON (AUDIT.md Phase 1).
-        Pass ``max_results=0`` to restore unlimited behavior, or pass a
-        ``file_path`` to scope the query.
+        Default cap: 100 rows. ``max_results=0`` restores "unlimited" but is
+        still bounded by the hard safety cap (1000 rows). Past observed
+        failure: project-wide call on a ~2 500-function repo returned a
+        180 k-char JSON that exceeded the MCP response token budget and
+        the agent saw an error instead of useful output.
         """
         from token_savior.project_indexer import is_path_excluded_from_scans
+
+        _HARD_FUNCTION_CAP = 1000  # always enforced regardless of max_results
 
         if file_path is not None:
             meta = _resolve_file(self.index, file_path)
@@ -905,26 +908,42 @@ class ProjectQueryEngine:
                         }
                     )
         total = len(result)
-        if max_results > 0 and total > max_results:
-            result = result[:max_results]
+        # Resolve effective cap: explicit max_results wins; max_results=0 still
+        # honors the hard safety cap so the response never overflows.
+        effective_cap = (
+            max_results if (0 < max_results < _HARD_FUNCTION_CAP)
+            else _HARD_FUNCTION_CAP
+        )
+        if total > effective_cap:
+            result = result[:effective_cap]
+            hint = (
+                f"showing first {effective_cap} of {total}. Pass "
+                "file_path=<path> to scope, or query specific names via "
+                "find_symbol(names=[...])."
+            )
+            if max_results == 0 or max_results >= _HARD_FUNCTION_CAP:
+                hint = (
+                    f"hard cap {_HARD_FUNCTION_CAP} hit ({total} total). "
+                    + hint
+                )
             result.append({
                 "_truncated": True,
-                "shown": max_results,
+                "shown": effective_cap,
                 "total": total,
-                "hint": (
-                    f"showing first {max_results} of {total}. Pass "
-                    "max_results=0 for all, or file_path=<path> to scope."
-                ),
+                "hint": hint,
             })
         return result
 
     def get_classes(self, file_path: str | None = None, max_results: int = 100) -> list[dict]:
         """Classes in a file or across the project.
 
-        Default cap: 100 rows. Pass ``max_results=0`` to restore unlimited,
-        or ``file_path=<path>`` to scope.
+        Default cap: 100 rows. ``max_results=0`` means "unlimited" but is
+        still bounded by a hard safety cap (1000 rows) — see get_functions
+        for the same pattern and rationale.
         """
         from token_savior.project_indexer import is_path_excluded_from_scans
+
+        _HARD_CLASS_CAP = 1000
 
         if file_path is not None:
             meta = _resolve_file(self.index, file_path)
@@ -952,16 +971,24 @@ class ProjectQueryEngine:
                         }
                     )
         total = len(result)
-        if max_results > 0 and total > max_results:
-            result = result[:max_results]
+        effective_cap = (
+            max_results if (0 < max_results < _HARD_CLASS_CAP)
+            else _HARD_CLASS_CAP
+        )
+        if total > effective_cap:
+            result = result[:effective_cap]
+            hint = (
+                f"showing first {effective_cap} of {total}. Pass "
+                "file_path=<path> to scope, or query specific names via "
+                "find_symbol(names=[...])."
+            )
+            if max_results == 0 or max_results >= _HARD_CLASS_CAP:
+                hint = f"hard cap {_HARD_CLASS_CAP} hit ({total} total). " + hint
             result.append({
                 "_truncated": True,
-                "shown": max_results,
+                "shown": effective_cap,
                 "total": total,
-                "hint": (
-                    f"showing first {max_results} of {total}. Pass "
-                    "max_results=0 for all, or file_path=<path> to scope."
-                ),
+                "hint": hint,
             })
         return result
 
@@ -1332,10 +1359,59 @@ class ProjectQueryEngine:
         return result
 
     def get_file_dependents(self, file_path: str, max_results: int = 0) -> list[str]:
-        """What files import from this file (from reverse_import_graph)."""
-        deps = self.index.reverse_import_graph.get(file_path)
+        """What files import from this file (from reverse_import_graph).
+
+        Tolerates the three common UX failures observed in production:
+        * absolute path passed when the index keys are project-relative
+        * Windows-style backslash separators
+        * the file exists in the index but has no inbound imports — return
+          an empty list with a ``_no_dependents`` marker instead of a hard
+          "not found" error so the agent doesn't think the tool broke.
+        """
+        # Normalize: project-relative + POSIX separators
+        normalized = file_path.replace("\\", "/")
+        if os.path.isabs(normalized):
+            # ProjectQueryEngine doesn't carry root_path; try common roots
+            # by stripping any registered project root prefix.
+            for known in self.index.files:
+                if normalized.endswith("/" + known):
+                    normalized = known
+                    break
+
+        deps = self.index.reverse_import_graph.get(normalized)
+        if deps is None and normalized != file_path:
+            deps = self.index.reverse_import_graph.get(file_path)
+
         if deps is None:
-            return [f"Error: '{file_path}' not found in reverse import graph"]
+            # File might be indexed but simply have no inbound imports
+            # (terminal modules, scripts, generated entrypoints).
+            file_indexed = (
+                normalized in self.index.files
+                or file_path in self.index.files
+            )
+            if file_indexed:
+                return [{
+                    "_no_dependents": True,
+                    "file": normalized,
+                    "hint": (
+                        "File is indexed but no other file imports it. "
+                        "This is normal for entrypoints, scripts, or "
+                        "leaf modules."
+                    ),
+                }]
+            # Suggest closest known file when path is wrong
+            import difflib
+            close = difflib.get_close_matches(
+                normalized, list(self.index.files.keys()), n=3, cutoff=0.6
+            )
+            suggestion = f" Did you mean: {', '.join(close)}?" if close else ""
+            return [{
+                "error": f"'{file_path}' not found in reverse import graph.{suggestion}",
+                "hint": (
+                    "If the file was added or moved recently, run reindex() "
+                    "first — the import graph is built at index time."
+                ),
+            }]
         result = sorted(deps)
         if max_results > 0:
             result = result[:max_results]

--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -146,9 +146,23 @@ _LEAN_EXCLUDES: set[str] = {
     "reasoning_save", "reasoning_search", "reasoning_list",
     # Corpus — 0 calls in tsbench + VPS
     "corpus_build", "corpus_query",
-    # Niche analysis — edge cases, rare in practice
+    # Niche analysis — 0 calls in 30d production (handlers kept for
+    # backward compat; full profile re-exposes them).
     "get_duplicate_classes", "get_call_predictions",
+    "get_backward_slice", "get_components", "get_related_symbols",
+    "search_in_symbols",  # subset of search_codebase
+    "summarize_patch_by_symbol",  # subset of get_changed_symbols
+    "find_cross_project_deps",
     "pack_context",
+    # Composites that overlap with primitives — agents pick the
+    # primitives in 100 % of observed calls, never the composites.
+    "apply_refactoring",  # = rename / move / add_field / extract — already exposed
+    "apply_symbol_change_and_validate",  # = replace + run_impacted_tests
+    "audit_file",  # = find_dead_code + find_hotspots + find_semantic_duplicates
+    "verify_edit",  # static safety check, 0 production callers
+    # Library API — 3 tools, 0 calls in 30d.
+    "find_library_symbol_by_description",
+    "get_library_symbol", "list_library_symbols",
     # Tool capture — agent never invokes capture_put/purge directly
     # (hook handles that). capture_aggregate/list also rarely needed
     # interactively. capture_get + capture_search stay visible so the

--- a/src/token_savior/server_handlers/code_nav.py
+++ b/src/token_savior/server_handlers/code_nav.py
@@ -584,7 +584,23 @@ def _q_find_symbol(qfns, args: dict[str, Any]):
     batch = _batch_dispatch(qfns, args, _q_find_symbol)
     if batch is not None:
         return batch
-    name = args["name"]
+    name = args.get("name")
+    if not name:
+        # Common failure mode: agent forgot to pass any name. The MCP
+        # validator already raises a generic "Input validation error" but
+        # that doesn't tell the agent what to do next. Return a structured
+        # hint so the next call goes through.
+        return {
+            "error": "find_symbol requires either 'name=<str>' or 'names=[<str>, ...]'.",
+            "_hints": {
+                "single": "find_symbol(name='create_user')",
+                "batch": "find_symbol(names=['create_user', 'update_user', 'delete_user'])  # max 10",
+                "alternatives": [
+                    "search_codebase(pattern='...') if you only have keywords",
+                    "get_structure_summary(file_path='...') for a file's TOC",
+                ],
+            },
+        }
     result = qfns["find_symbol"](name, level=args.get("level", 0))
     if isinstance(result, dict) and "error" in result:
         result["_suggestion"] = (

--- a/src/token_savior/server_handlers/edit.py
+++ b/src/token_savior/server_handlers/edit.py
@@ -7,6 +7,7 @@ import os
 from token_savior.edit_ops import (
     add_field_to_model,
     apply_refactoring,
+    edit_lines_in_symbol,
     insert_near_symbol,
     move_symbol,
     replace_symbol_source,
@@ -37,6 +38,21 @@ def _h_insert_near_symbol(slot: _ProjectSlot, args: dict) -> object:
         args["content"],
         position=args.get("position", "after"),
         file_path=args.get("file_path"),
+    )
+    if result.get("ok"):
+        slot.indexer.reindex_file(result["file"])
+    return result
+
+
+def _h_edit_lines_in_symbol(slot: _ProjectSlot, args: dict) -> object:
+    _prep(slot)
+    result = edit_lines_in_symbol(
+        slot.indexer._project_index,
+        args["symbol_name"],
+        args["old_string"],
+        args["new_string"],
+        file_path=args.get("file_path"),
+        replace_all=bool(args.get("replace_all", False)),
     )
     if result.get("ok"):
         slot.indexer.reindex_file(result["file"])
@@ -143,6 +159,7 @@ def _h_apply_refactoring(slot: _ProjectSlot, args: dict) -> object:
 HANDLERS: dict[str, object] = {
     "replace_symbol_source": _h_replace_symbol_source,
     "insert_near_symbol": _h_insert_near_symbol,
+    "edit_lines_in_symbol": _h_edit_lines_in_symbol,
     "verify_edit": _h_verify_edit,
     "apply_symbol_change_and_validate": _h_apply_symbol_change_and_validate,
     "add_field_to_model": _h_add_field_to_model,

--- a/src/token_savior/slot_manager.py
+++ b/src/token_savior/slot_manager.py
@@ -244,9 +244,40 @@ class SlotManager:
             for root, slot in self.projects.items():
                 if os.path.basename(root) == project_hint:
                     return slot, ""
+            # Case-insensitive basename match (often the agent says
+            # "TSBench" or "Estalle" with different casing).
+            hint_lower = project_hint.lower()
+            for root, slot in self.projects.items():
+                if os.path.basename(root).lower() == hint_lower:
+                    return slot, ""
+            # Substring fuzzy match (one unique candidate only — bail if
+            # ambiguous so we don't silently switch to the wrong project).
+            substring_matches = [
+                (root, slot) for root, slot in self.projects.items()
+                if hint_lower in os.path.basename(root).lower()
+            ]
+            if len(substring_matches) == 1:
+                return substring_matches[0][1], ""
+            # Build a "did you mean?" suggestion based on edit distance.
+            import difflib
+            basenames = [os.path.basename(r) for r in self.projects]
+            close = difflib.get_close_matches(project_hint, basenames, n=3, cutoff=0.5)
+            suggestion = (
+                f" Did you mean: {', '.join(close)}?"
+                if close
+                else ""
+            )
+            ambiguous_note = ""
+            if len(substring_matches) > 1:
+                multi = [os.path.basename(r) for r, _ in substring_matches]
+                ambiguous_note = (
+                    f" Multiple substring matches: {', '.join(multi)} — "
+                    "be more specific."
+                )
             return None, (
-                f"Project '{project_hint}' not found. "
-                f"Known projects: {', '.join(os.path.basename(r) for r in self.projects)}"
+                f"Project '{project_hint}' not found.{suggestion}"
+                f"{ambiguous_note} "
+                f"Known projects: {', '.join(basenames)}"
             )
 
         if self.active_root and self.active_root in self.projects:

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -152,6 +152,21 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "required": ["symbol_name", "new_source"],
         },
     },
+    "edit_lines_in_symbol": {
+        "description": "Exact string-replace inside an indexed symbol's body (like Edit but symbol-scoped, no Read first needed).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "symbol_name": {"type": "string", "description": "Function/method/class name to edit inside."},
+                "old_string": {"type": "string", "description": "Exact text to find inside the symbol body (must be unique within the symbol unless replace_all=true)."},
+                "new_string": {"type": "string", "description": "Replacement text."},
+                "file_path": {"type": "string", "description": "Optional file path to disambiguate symbols."},
+                "replace_all": {"type": "boolean", "description": "If true, replace every occurrence in the symbol body (default false)."},
+                **_PROJECT_PARAM,
+            },
+            "required": ["symbol_name", "old_string", "new_string"],
+        },
+    },
     "insert_near_symbol": {
         "description": (
         'Insert content before or after an indexed symbol.'

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -1044,7 +1044,13 @@ class TestProjectQueryFunctions:
 
     def test_get_file_dependents_not_found(self):
         deps = self.funcs["get_file_dependents"]("nonexistent.py")
-        assert "Error" in deps[0]
+        # Error response is now a structured dict (was a bare string).
+        # Check the rich shape so the agent gets a useful "did you mean"
+        # plus a "run reindex" hint instead of a one-liner.
+        assert isinstance(deps[0], dict)
+        assert "error" in deps[0]
+        assert "nonexistent.py" in deps[0]["error"]
+        assert "hint" in deps[0]
 
     def test_search_codebase(self):
         results = self.funcs["search_codebase"]("class ")

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -63,7 +63,9 @@ class TestToolSchemas:
         # +1 find_library_symbol_by_description (feature 3 — semantic library lookup) = 94.
         # +6 tool_capture (capture_put/search/get/aggregate/list/purge — sandbox of
         #   verbose tool outputs, response to mksglu/context-mode) = 100.
-        assert len(TOOL_SCHEMAS) == 100, f"Expected 100 tools, got {len(TOOL_SCHEMAS)}"
+        # +1 edit_lines_in_symbol (symbol-scoped string-replace, captures the
+        #   80%+ of native Edit calls landing on indexed code files) = 101.
+        assert len(TOOL_SCHEMAS) == 101, f"Expected 101 tools, got {len(TOOL_SCHEMAS)}"
 
     def test_server_tools_match_schemas(self):
         from token_savior.server import TOOLS


### PR DESCRIPTION
## Summary

Mines 30 days of production session logs (37 k tool calls, 821 sessions) to identify TS tool failure modes and surface gaps that drive the agent to native Bash/Read/Edit. Five real-world fixes + one new tool + 12 dead tools moved to lean exclude.

## Failure modes fixed

| Tool | Prod failure rate | Fix |
|---|---:|---|
| `switch_project` | **29 %** (181 / 628) | case-insensitive basename + single-substring fuzzy + difflib "did you mean?" |
| `find_symbol` | **26 %** (60 / 234) | structured error when neither `name` nor `names` provided, instead of MCP generic "Input validation error" |
| `get_functions` | **43 %** (25 / 58) | hard 1000-row safety cap honored even with `max_results=0`; structured `_truncated` marker (was 133-180 k char overflow) |
| `get_classes` | (mirror) | matching hard cap |
| `get_file_dependents` | **75 %** (9 / 12) | absolute-path + Windows-separator normalization; `_no_dependents` marker when file is indexed but has no inbound imports; difflib suggestion when path is wrong; "run reindex()" hint |

## New tool: `edit_lines_in_symbol`

Production audit: agent runs native `Edit` on code files ~**5 305** times vs `replace_symbol_source` (274) + `insert_near_symbol` (61). `Edit` wins 13× on indexed code because:

- `replace_symbol_source` requires a full new-body → forces Read first and rewrites unchanged lines
- `Edit` is precise (line-level) and friction-free

`edit_lines_in_symbol(symbol_name, old_string, new_string)` resolves the symbol body via the index and does an exact string-replace **scoped to that body**, not the whole file. Errors structured with hints when `old_string` is missing or appears more than once.

Closes the most quoted gap: "TS has no tool that matches Edit's ergonomics on indexed code".

## Lean expansion (12 more zero-call tools)

| Group | Tools |
|---|---|
| Niche analysis (0 calls / 30 d) | `get_backward_slice`, `get_components`, `get_related_symbols`, `search_in_symbols` (subset of search_codebase), `summarize_patch_by_symbol` (subset of get_changed_symbols), `find_cross_project_deps` |
| Composites overlapping primitives (0 calls) | `apply_refactoring`, `apply_symbol_change_and_validate`, `audit_file`, `verify_edit` |
| Library API (0 calls / 30 d) | `find_library_symbol_by_description`, `get_library_symbol`, `list_library_symbols` |

Handlers stay registered — `full` profile or explicit invocation still work — only the manifest hides them.

**Manifest impact** (lean profile, projected post-merge of [#21](https://github.com/Mibayy/token-savior/pull/21)):

| State | Tokens |
|---|---:|
| pre-#21 lean | 12 615 |
| post-#21 lean | 8 750 |
| **post-this-PR lean** | **7 800** |

## Tests

- **1 441 passed, 4 skipped, 0 failed**.
- Updated `test_get_file_dependents_not_found` to match the new structured error response.
- Bumped `test_tool_count` 100 → 101 with comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)