### PR TITLE
cleanup(round-3+5): delete 15 dead tools + fuse 21 memory admin tools

### DIFF
--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -129,17 +129,12 @@ TOOLS = [Tool(name=name, description=s["description"], inputSchema=s["inputSchem
 # `run_project_action` (5/3330 calls on VPS, but the workflow needs
 # both or none).
 _LEAN_EXCLUDES: set[str] = {
-    # Memory engine — opt-in only (memory_save kept; the user-facing
-    # "remember this" path must stay visible by default to honour the
-    # README's "nothing forgotten between sessions" promise)
+    # Memory engine — opt-in only. memory_save / memory_index / memory_search
+    # / memory_get / memory_delete are user-facing and stay visible.
+    # memory_admin is a new fusion (Round 5) replacing 21 admin tools that
+    # were previously listed here individually.
     "memory_search", "memory_get", "memory_index",
-    "memory_delete", "memory_top", "memory_why", "memory_timeline",
-    "memory_session_history", "memory_prompts", "memory_mode",
-    "memory_archive", "memory_status", "memory_bus_push", "memory_bus_list",
-    "memory_consistency", "memory_quarantine_list", "memory_maintain",
-    "memory_doctor", "memory_vector_reindex", "memory_distill",
-    "memory_dedup_sweep", "memory_roi_gc", "memory_roi_stats",
-    "memory_from_bash", "memory_set_global",
+    "memory_delete", "memory_admin",
     # Reasoning — memory-adjacent, 0 calls in tsbench + VPS
     "reasoning_save", "reasoning_search", "reasoning_list",
     # Corpus — 0 calls in tsbench + VPS
@@ -198,14 +193,8 @@ if _PROFILE != "full":
 # costs ~50-100 tokens whether it's used or not.
 if os.environ.get("TS_MEMORY_DISABLE") == "1":
     _MEMORY_GATED = {
-        "memory_save", "memory_archive", "memory_set_global", "memory_mode",
-        "memory_index", "memory_search", "memory_get", "memory_top",
-        "memory_status", "memory_session_history", "memory_timeline",
-        "memory_prompts", "memory_doctor", "memory_consistency",
-        "memory_quarantine_list", "memory_maintain", "memory_distill",
-        "memory_dedup_sweep", "memory_roi_gc", "memory_roi_stats",
-        "memory_vector_reindex", "memory_delete", "memory_why",
-        "memory_bus_push", "memory_bus_list", "memory_from_bash",
+        "memory_save", "memory_index", "memory_search", "memory_get",
+        "memory_delete", "memory_admin",
         "reasoning_save", "reasoning_search", "reasoning_list",
         "corpus_build", "corpus_query",
     }

--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -21,9 +21,7 @@ graph pollution, no shared RAM between unrelated projects.
     "What does X call?"                -> get_dependencies(X)
     "Impact of changing X"             -> get_change_impact(X)
     "Orient me on X (source+callers)"  -> get_full_context(X)
-    "Find Y in code, want symbol ctx"  -> search_in_symbols(pattern=Y)
     "Raw regex grep"                   -> search_codebase(pattern=Y)
-    "Audit this file"                  -> audit_file(file_path=F)
     "Dead / unused code"               -> find_dead_code
     "Complexity hotspots"              -> find_hotspots (T0=most actionable)
     "Breaking API changes"             -> detect_breaking_changes (T0=breaking)
@@ -146,23 +144,9 @@ _LEAN_EXCLUDES: set[str] = {
     "reasoning_save", "reasoning_search", "reasoning_list",
     # Corpus — 0 calls in tsbench + VPS
     "corpus_build", "corpus_query",
-    # Niche analysis — 0 calls in 30d production (handlers kept for
-    # backward compat; full profile re-exposes them).
-    "get_duplicate_classes", "get_call_predictions",
-    "get_backward_slice", "get_components", "get_related_symbols",
-    "search_in_symbols",  # subset of search_codebase
-    "summarize_patch_by_symbol",  # subset of get_changed_symbols
-    "find_cross_project_deps",
-    "pack_context",
-    # Composites that overlap with primitives — agents pick the
-    # primitives in 100 % of observed calls, never the composites.
-    "apply_refactoring",  # = rename / move / add_field / extract — already exposed
-    "apply_symbol_change_and_validate",  # = replace + run_impacted_tests
-    "audit_file",  # = find_dead_code + find_hotspots + find_semantic_duplicates
-    "verify_edit",  # static safety check, 0 production callers
-    # Library API — 3 tools, 0 calls in 30d.
-    "find_library_symbol_by_description",
-    "get_library_symbol", "list_library_symbols",
+    # search_in_symbols is a subset of search_codebase — kept registered
+    # for backwards compatibility but excluded from lean.
+    "search_in_symbols",
     # Tool capture — agent never invokes capture_put/purge directly
     # (hook handles that). capture_aggregate/list also rarely needed
     # interactively. capture_get + capture_search stay visible so the

--- a/src/token_savior/server_handlers/analysis.py
+++ b/src/token_savior/server_handlers/analysis.py
@@ -2,7 +2,7 @@
 
 Covers: analyze_config, find_dead_code, find_hotspots (fused
 complexity/allocation/performance kinds), detect_breaking_changes,
-find_cross_project_deps, analyze_docker.
+analyze_docker.
 """
 
 from __future__ import annotations
@@ -16,15 +16,9 @@ from token_savior import server_state as state
 from token_savior.breaking_changes import detect_breaking_changes as run_breaking_changes
 from token_savior.complexity import find_hotspots as run_hotspots
 from token_savior.config_analyzer import analyze_config as run_config_analysis
-from token_savior.cross_project import find_cross_project_deps as run_cross_project
 from token_savior.db_schema import get_db_schema as run_get_db_schema
 from token_savior.dead_code import find_dead_code as run_dead_code
 from token_savior.docker_analyzer import analyze_docker as run_docker_analysis
-from token_savior.library_api import (
-    find_library_symbol_by_description as run_find_library_symbol_by_description,
-    get_library_symbol as run_get_library_symbol,
-    list_library_symbols as run_list_library_symbols,
-)
 from token_savior.java_quality import (
     find_allocation_hotspots as run_allocation_hotspots,
     find_performance_hotspots as run_performance_hotspots,
@@ -138,86 +132,9 @@ def _h_detect_breaking_changes(slot: _ProjectSlot, args: dict) -> object:
     return result
 
 
-def _h_find_cross_project_deps(slot: _ProjectSlot, args: dict) -> object:
-    loaded: dict[str, ProjectIndex] = {}
-    for root, sibling_slot in state._slot_mgr.projects.items():
-        state._slot_mgr.ensure(sibling_slot)
-        if sibling_slot.indexer and sibling_slot.indexer._project_index:
-            loaded[os.path.basename(root)] = sibling_slot.indexer._project_index
-    return run_cross_project(loaded)
-
-
 def _h_analyze_docker(slot: _ProjectSlot, args: dict) -> object:
     _prep(slot)
     return run_docker_analysis(slot.indexer._project_index)
-
-
-def _h_audit_file(slot: _ProjectSlot, args: dict) -> object:
-    """Mega-batch: dead_code + hotspots + semantic duplicates filtered to one file.
-
-    Replaces three round-trips with a single call when the agent is triaging a
-    specific file. Each section is capped tight; raise the per-section limits
-    via ``max_dead``/``max_hotspots``/``max_dup_groups`` for a deeper audit.
-    """
-    _prep(slot)
-    file_path = args.get("file_path")
-    if not file_path:
-        return {"ok": False, "error": "file_path is required"}
-
-    index = slot.indexer._project_index
-    out: dict[str, Any] = {"file": file_path}
-
-    # Dead code — filter project-wide result to this file only.
-    try:
-        loaded: dict[str, ProjectIndex] = {}
-        for root, sibling_slot in state._slot_mgr.projects.items():
-            state._slot_mgr.ensure(sibling_slot)
-            if sibling_slot.indexer and sibling_slot.indexer._project_index:
-                loaded[os.path.basename(root)] = sibling_slot.indexer._project_index
-        dead_raw = run_dead_code(
-            index,
-            max_results=args.get("max_dead", 50),
-            sibling_indices=loaded,
-        )
-        dead_lines = [ln for ln in str(dead_raw).splitlines() if file_path in ln]
-        out["dead_code"] = "\n".join(dead_lines) if dead_lines else "(none)"
-    except Exception as exc:  # pragma: no cover
-        out["dead_code"] = f"error: {exc}"
-
-    # Hotspots — same filter.
-    try:
-        hot_raw = run_hotspots(
-            index,
-            max_results=args.get("max_hotspots", 50),
-            min_score=args.get("min_score", 0.0),
-        )
-        hot_lines = [ln for ln in str(hot_raw).splitlines() if file_path in ln]
-        out["hotspots"] = "\n".join(hot_lines) if hot_lines else "(none)"
-    except Exception as exc:  # pragma: no cover
-        out["hotspots"] = f"error: {exc}"
-
-    # Semantic duplicates — filter groups that touch the file.
-    try:
-        qfns = slot.query_fns
-        find_dups = qfns.get("find_semantic_duplicates") if qfns else None
-        if find_dups is not None:
-            dups = find_dups(
-                min_lines=args.get("min_lines", 6),
-                max_groups=args.get("max_dup_groups", 20),
-                max_members_per_group=5,
-            )
-            touching = []
-            for group in dups.get("groups", []) if isinstance(dups, dict) else []:
-                members = group.get("members", [])
-                if any(m.get("file") == file_path for m in members):
-                    touching.append(group)
-            out["duplicates"] = touching or "(none)"
-        else:
-            out["duplicates"] = "(unavailable)"
-    except Exception as exc:  # pragma: no cover
-        out["duplicates"] = f"error: {exc}"
-
-    return out
 
 
 def _h_get_db_schema(slot: _ProjectSlot, args: dict) -> object:
@@ -232,59 +149,11 @@ def _h_get_db_schema(slot: _ProjectSlot, args: dict) -> object:
     )
 
 
-def _h_get_library_symbol(slot: _ProjectSlot, args: dict) -> object:
-    package = args.get("package")
-    symbol_path = args.get("symbol_path", "")
-    if not package:
-        return {"ok": False, "error": "'package' is required"}
-    return run_get_library_symbol(
-        package,
-        symbol_path,
-        project_root=slot.root,
-        max_files=int(args.get("max_files", 200)),
-    )
-
-
-def _h_list_library_symbols(slot: _ProjectSlot, args: dict) -> object:
-    package = args.get("package")
-    if not package:
-        return {"ok": False, "error": "'package' is required"}
-    return run_list_library_symbols(
-        package,
-        project_root=slot.root,
-        pattern=args.get("pattern"),
-        max_files=int(args.get("max_files", 100)),
-        limit=int(args.get("limit", 100)),
-    )
-
-
-def _h_find_library_symbol_by_description(slot: _ProjectSlot, args: dict) -> object:
-    package = args.get("package")
-    description = args.get("description")
-    if not package:
-        return {"ok": False, "error": "'package' is required"}
-    if not description:
-        return {"ok": False, "error": "'description' is required"}
-    return run_find_library_symbol_by_description(
-        package,
-        description,
-        project_root=slot.root,
-        limit=int(args.get("limit", 10)),
-        max_files=int(args.get("max_files", 100)),
-        candidate_pool=int(args.get("candidate_pool", 200)),
-    )
-
-
 HANDLERS: dict[str, Any] = {
     "analyze_config": _h_analyze_config,
     "find_dead_code": _h_find_dead_code,
     "find_hotspots": _h_find_hotspots,
     "detect_breaking_changes": _h_detect_breaking_changes,
-    "find_cross_project_deps": _h_find_cross_project_deps,
     "analyze_docker": _h_analyze_docker,
-    "audit_file": _h_audit_file,
     "get_db_schema": _h_get_db_schema,
-    "get_library_symbol": _h_get_library_symbol,
-    "list_library_symbols": _h_list_library_symbols,
-    "find_library_symbol_by_description": _h_find_library_symbol_by_description,
 }

--- a/src/token_savior/server_handlers/code_nav.py
+++ b/src/token_savior/server_handlers/code_nav.py
@@ -707,21 +707,10 @@ QFN_HANDLERS: dict[str, object] = {
     "get_env_usage": lambda q, a: q["get_env_usage"](
         a["var_name"], max_results=a.get("max_results", 0)
     ),
-    "get_components": lambda q, a: q["get_components"](
-        file_path=a.get("file_path"), max_results=a.get("max_results", 0)
-    ),
     "get_feature_files": lambda q, a: q["get_feature_files"](
         a["keyword"], max_results=a.get("max_results", 0)
     ),
     "get_entry_points": lambda q, a: q["get_entry_points"](max_results=a.get("max_results", 20)),
-    "get_backward_slice": lambda q, a: q["get_backward_slice"](
-        a["name"], a["variable"], a["line"], file_path=a.get("file_path")
-    ),
-    "pack_context": lambda q, a: q["pack_context"](
-        a["query"],
-        budget_tokens=a.get("budget_tokens", 4000),
-        max_symbols=a.get("max_symbols", 20),
-    ),
     "find_semantic_duplicates": lambda q, a: q["find_semantic_duplicates"](
         min_lines=a.get("min_lines", 2),
         max_groups=a.get("max_groups", 10),
@@ -730,10 +719,5 @@ QFN_HANDLERS: dict[str, object] = {
     ),
     "find_import_cycles": lambda q, a: q["find_import_cycles"](
         max_cycles=a.get("max_cycles", 20),
-    ),
-    "get_duplicate_classes": lambda q, a: q["get_duplicate_classes"](
-        a.get("name"),
-        max_results=a.get("max_results", 0),
-        simple_name_mode=a.get("simple_name_mode", False),
     ),
 }

--- a/src/token_savior/server_handlers/edit.py
+++ b/src/token_savior/server_handlers/edit.py
@@ -1,12 +1,9 @@
-"""Handlers for symbol-level edit tools (replace/insert/verify/apply)."""
+"""Handlers for symbol-level edit tools (replace, insert, edit, move, add_field)."""
 
 from __future__ import annotations
 
-import os
-
 from token_savior.edit_ops import (
     add_field_to_model,
-    apply_refactoring,
     edit_lines_in_symbol,
     insert_near_symbol,
     move_symbol,
@@ -14,7 +11,6 @@ from token_savior.edit_ops import (
 )
 from token_savior.server_runtime import _prep
 from token_savior.slot_manager import _ProjectSlot
-from token_savior.workflow_ops import apply_symbol_change_and_validate
 
 
 def _h_replace_symbol_source(slot: _ProjectSlot, args: dict) -> object:
@@ -59,53 +55,6 @@ def _h_edit_lines_in_symbol(slot: _ProjectSlot, args: dict) -> object:
     return result
 
 
-def _h_verify_edit(slot: _ProjectSlot, args: dict) -> object:
-    """P9 — pure static EditSafety certificate, no mutation."""
-    from token_savior.edit_ops import resolve_symbol_location
-    from token_savior.edit_verifier import verify_edit
-
-    _prep(slot)
-    index = slot.indexer._project_index if slot.indexer else None
-    if index is None:
-        return "Error: index not built. Call reindex first."
-    symbol_name = args["symbol_name"]
-    new_source = args["new_source"]
-    loc = resolve_symbol_location(
-        index, symbol_name, file_path=args.get("file_path")
-    )
-    if "error" in loc:
-        return f"Error: {loc['error']}"
-    full_path = (
-        loc["file"]
-        if os.path.isabs(loc["file"])
-        else os.path.join(index.root_path, loc["file"])
-    )
-    try:
-        with open(full_path, "r", encoding="utf-8") as fh:
-            source_lines = fh.read().splitlines()
-    except OSError as exc:
-        return f"Error: cannot read {full_path}: {exc}"
-    old_source = "\n".join(source_lines[loc["line"] - 1 : loc["end_line"]])
-    cert = verify_edit(old_source, new_source, symbol_name, index.root_path)
-    return cert.format()
-
-
-def _h_apply_symbol_change_and_validate(slot: _ProjectSlot, args: dict) -> object:
-    _prep(slot)
-    return apply_symbol_change_and_validate(
-        slot.indexer,
-        args["symbol_name"],
-        args["new_source"],
-        file_path=args.get("file_path"),
-        max_tests=args.get("max_tests", 20),
-        timeout_sec=args.get("timeout_sec", 120),
-        max_output_chars=args.get("max_output_chars", 12000),
-        include_output=args.get("include_output", False),
-        compact=args.get("compact", False),
-        rollback_on_failure=args.get("rollback_on_failure", False),
-    )
-
-
 def _h_add_field_to_model(slot: _ProjectSlot, args: dict) -> object:
     _prep(slot)
     result = add_field_to_model(
@@ -134,35 +83,10 @@ def _h_move_symbol(slot: _ProjectSlot, args: dict) -> object:
     return result
 
 
-def _h_apply_refactoring(slot: _ProjectSlot, args: dict) -> object:
-    _prep(slot)
-    result = apply_refactoring(
-        slot.indexer._project_index,
-        refactoring_type=args["type"],
-        symbol=args.get("symbol"),
-        new_name=args.get("new_name"),
-        target_file=args.get("target_file"),
-        create_if_missing=args.get("create_if_missing", True),
-        model=args.get("model"),
-        field_name=args.get("field_name"),
-        field_type=args.get("field_type"),
-        file_path=args.get("file_path"),
-        after=args.get("after"),
-        start_line=args.get("start_line"),
-        end_line=args.get("end_line"),
-    )
-    if result.get("ok"):
-        slot.indexer.reindex()
-    return result
-
-
 HANDLERS: dict[str, object] = {
     "replace_symbol_source": _h_replace_symbol_source,
     "insert_near_symbol": _h_insert_near_symbol,
     "edit_lines_in_symbol": _h_edit_lines_in_symbol,
-    "verify_edit": _h_verify_edit,
-    "apply_symbol_change_and_validate": _h_apply_symbol_change_and_validate,
     "add_field_to_model": _h_add_field_to_model,
     "move_symbol": _h_move_symbol,
-    "apply_refactoring": _h_apply_refactoring,
 }

--- a/src/token_savior/server_handlers/git.py
+++ b/src/token_savior/server_handlers/git.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from token_savior.compact_ops import get_changed_symbols
-from token_savior.git_ops import build_commit_summary, summarize_patch_by_symbol
+from token_savior.git_ops import build_commit_summary
 from token_savior.git_tracker import get_git_status
 from token_savior.server_runtime import _prep
 from token_savior.slot_manager import _ProjectSlot
@@ -23,16 +23,6 @@ def _h_get_changed_symbols(slot: _ProjectSlot, args: dict) -> object:
     )
 
 
-def _h_summarize_patch_by_symbol(slot: _ProjectSlot, args: dict) -> object:
-    _prep(slot)
-    return summarize_patch_by_symbol(
-        slot.indexer._project_index,
-        changed_files=args.get("changed_files"),
-        max_files=args.get("max_files", 20),
-        max_symbols_per_file=args.get("max_symbols_per_file", 20),
-    )
-
-
 def _h_build_commit_summary(slot: _ProjectSlot, args: dict) -> object:
     _prep(slot)
     return build_commit_summary(
@@ -46,6 +36,5 @@ def _h_build_commit_summary(slot: _ProjectSlot, args: dict) -> object:
 HANDLERS: dict[str, object] = {
     "get_git_status": _h_get_git_status,
     "get_changed_symbols": _h_get_changed_symbols,
-    "summarize_patch_by_symbol": _h_summarize_patch_by_symbol,
     "build_commit_summary": _h_build_commit_summary,
 }

--- a/src/token_savior/server_handlers/memory.py
+++ b/src/token_savior/server_handlers/memory.py
@@ -1285,40 +1285,64 @@ def _hm_memory_quarantine_list(arguments: dict[str, Any]) -> list[types.TextCont
 # ---------------------------------------------------------------------------
 
 
+
+def _mh_memory_admin(args):
+    """Dispatch memory admin ops via a single fusion tool.
+
+    Rationale: 21 admin tools (doctor, dedup_sweep, distill, roi_gc,
+    consistency, vector_reindex, maintain, …) all 0-call in 30 d
+    production. They were lean-excluded but still inflated the full
+    profile manifest by ~1500 tokens. memory_admin folds them into a
+    single tool with an `op` enum; agents that need them can still
+    reach every one, the manifest carries one schema instead of 21.
+    """
+    op = (args.get("op") or "").strip()
+    payload = {k: v for k, v in args.items() if k != "op"}
+    routes = {
+        "status": _mh_memory_status,
+        "top": _mh_memory_top,
+        "why": _mh_memory_why,
+        "timeline": _mh_memory_timeline,
+        "session_history": _mh_memory_session_history,
+        "prompts": _mh_memory_prompts,
+        "mode": _mh_memory_mode,
+        "archive": _mh_memory_archive,
+        "bus_push": _mh_memory_bus_push,
+        "bus_list": _mh_memory_bus_list,
+        "consistency": _hm_memory_consistency,
+        "quarantine_list": _hm_memory_quarantine_list,
+        "maintain": _mh_memory_maintain,
+        "doctor": _mh_memory_doctor,
+        "vector_reindex": _mh_memory_vector_reindex,
+        "distill": _mh_memory_distill,
+        "dedup_sweep": _mh_memory_dedup_sweep,
+        "roi_gc": _mh_memory_roi_gc,
+        "roi_stats": _mh_memory_roi_stats,
+        "from_bash": _mh_memory_from_bash,
+        "set_global": _mh_memory_set_global,
+    }
+    handler = routes.get(op)
+    if handler is None:
+        return (
+            f"Unknown op '{op}'. Valid: {', '.join(sorted(routes))}."
+        )
+    return handler(payload)
+
+
 HANDLERS: dict[str, Any] = {
-    "memory_bus_push": _mh_memory_bus_push,
-    "memory_bus_list": _mh_memory_bus_list,
     "reasoning_save": _mh_reasoning_save,
     "reasoning_search": _mh_reasoning_search,
     "reasoning_list": _mh_reasoning_list,
     "memory_save": _mh_memory_save,
     "memory_search": _mh_memory_search,
-    "memory_session_history": _mh_memory_session_history,
     "memory_get": _mh_memory_get,
     "memory_delete": _mh_memory_delete,
     "memory_index": _mh_memory_index,
-    "memory_timeline": _mh_memory_timeline,
-    "memory_prompts": _mh_memory_prompts,
-    "memory_mode": _mh_memory_mode,
     "corpus_build": _mh_corpus_build,
     "corpus_query": _mh_corpus_query,
-    "memory_archive": _mh_memory_archive,
-    "memory_status": _mh_memory_status,
-    "memory_maintain": _mh_memory_maintain,
-    "memory_from_bash": _mh_memory_from_bash,
-    "memory_doctor": _mh_memory_doctor,
-    "memory_vector_reindex": _mh_memory_vector_reindex,
-    "memory_distill": _mh_memory_distill,
-    "memory_dedup_sweep": _mh_memory_dedup_sweep,
-    "memory_roi_gc": _mh_memory_roi_gc,
-    "memory_roi_stats": _mh_memory_roi_stats,
-    "memory_why": _mh_memory_why,
-    "memory_top": _mh_memory_top,
-    "memory_set_global": _mh_memory_set_global,
+    "memory_admin": _mh_memory_admin,
 }
 
 
 ADMIN_HANDLERS: dict[str, Any] = {
-    "memory_consistency": _hm_memory_consistency,
-    "memory_quarantine_list": _hm_memory_quarantine_list,
 }

--- a/src/token_savior/server_handlers/stats.py
+++ b/src/token_savior/server_handlers/stats.py
@@ -575,85 +575,6 @@ def _hm_get_lattice_stats(arguments: dict[str, Any]) -> list[types.TextContent]:
     return [TextContent(type="text", text="\n".join(lines))]
 
 
-def _hm_get_call_predictions(arguments: dict[str, Any]) -> list[types.TextContent]:
-    tool_name = arguments.get("tool_name", "")
-    symbol_name = arguments.get("symbol_name", "")
-    top_k = int(arguments.get("top_k", 5))
-    preds = state._prefetcher.predict_next(tool_name, symbol_name, top_k=top_k)
-    if not preds:
-        return [TextContent(
-            type="text",
-            text=f"No transitions recorded for state '{tool_name}:{symbol_name}' yet.",
-        )]
-    lines = [f"Markov predictions after {tool_name}({symbol_name}):"]
-    for st, prob in preds:
-        lines.append(f"  {prob*100:5.1f}%  {st}")
-    return [TextContent(type="text", text="\n".join(lines))]
-
-
-def _hm_get_related_symbols(arguments: dict[str, Any]) -> list[types.TextContent]:
-    """Unified dispatcher: community / rwr / cluster / coactive."""
-    method = (arguments.get("method") or "community").strip().lower()
-
-    if method == "coactive":
-        return _hm_get_coactive_symbols(arguments)
-
-    if method == "community":
-        sym = arguments.get("name") or arguments.get("symbol")
-        cname = arguments.get("community_name") or (
-            arguments.get("name") if arguments.get("list_all") else None
-        )
-        list_all = bool(arguments.get("list_all", False))
-        if list_all or (not sym and not cname):
-            return _hm_get_community({
-                "list_all": True,
-                "min_size": arguments.get("min_size", 2),
-                "max_results": arguments.get("max_results", 30),
-                "max_members_preview": arguments.get("max_members_preview", 8),
-            })
-        return _hm_get_community({"symbol": sym, "name": cname})
-
-    if method in ("rwr", "cluster"):
-        import json
-        from token_savior import server_state as st_mod
-        from token_savior.server_runtime import _prep
-
-        name = (arguments.get("name") or "").strip()
-        if not name:
-            return [TextContent(
-                type="text",
-                text=f"Error: 'name' required for method='{method}'.",
-            )]
-        slot, err = st_mod._slot_mgr.resolve(arguments.get("project"))
-        if err or slot is None:
-            return [TextContent(type="text", text=f"Error: {err or 'no slot'}")]
-        _prep(slot)
-        if slot.query_fns is None:
-            return [TextContent(
-                type="text",
-                text=f"Error: index not built for '{slot.root}'. Call reindex first.",
-            )]
-        qfns = slot.query_fns
-        if method == "cluster":
-            result = qfns["get_symbol_cluster"](
-                name, max_members=int(arguments.get("max_members", 30)),
-            )
-        else:
-            result = qfns["get_relevance_cluster"](
-                name,
-                budget=int(arguments.get("budget", 10)),
-                include_reverse=bool(arguments.get("include_reverse", True)),
-            )
-        if isinstance(result, str):
-            return [TextContent(type="text", text=result)]
-        return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
-
-    return [TextContent(
-        type="text",
-        text=f"Unknown method '{method}'. Valid: community, rwr, cluster, coactive.",
-    )]
-
-
 _STATS_CATEGORIES: dict[str, Any] = {
     "usage": _hm_get_usage_stats,
     "session_budget": _hm_get_session_budget,
@@ -681,6 +602,4 @@ def _hm_get_stats(arguments: dict[str, Any]) -> list[types.TextContent]:
 
 HANDLERS: dict[str, Any] = {
     "get_stats": _hm_get_stats,
-    "get_related_symbols": _hm_get_related_symbols,
-    "get_call_predictions": _hm_get_call_predictions,
 }

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -863,141 +863,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "required": ["type", "title", "content"],
         },
     },
-    "memory_maintain": {
-        "description": (
-        'Maintenance rollup: promote, relink, export, extract patterns.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "action": {"type": "string", "enum": ["promote", "relink", "export", "patterns"], "description": "Action"},
-                "dry_run": {"type": "boolean", "description": "Preview only"},
-                "output_dir": {"type": "string", "description": "Export dir"},
-                "window_days": {"type": "integer", "description": "Patterns window"},
-                "min_occurrences": {"type": "integer", "description": "Patterns threshold"},
-                **_PROJECT_PARAM,
-            },
-            "required": ["action"],
-        },
-    },
-    "memory_top": {
-        "description": (
-        'Rank observations by score, access_count, or age.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "limit": {"type": "integer", "description": "Default 20."},
-                "sort_by": {"type": "string", "enum": ["score", "access_count", "age"]},
-            },
-        },
-    },
-    "memory_why": {
-        "description": (
-        'Explain why a specific observation matched the last injection (recency, type, symbol, FTS).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer"},
-                "query": {"type": "string", "description": "Optional FTS query."},
-            },
-            "required": ["id"],
-        },
-    },
-    "memory_doctor": {
-        "description": (
-        'Memory health report: orphans, near-dupes, incomplete obs, vector coverage, hook wiring.'   ),
-        "inputSchema": {"type": "object", "properties": {}},
-    },
-    "memory_vector_reindex": {
-        "description": (
-        'Backfill obs_vectors for observations missing an embedding. No-op if sqlite-vec/fastembed unavailable.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "limit": {"type": "integer", "description": "Max obs to index this run (default 500)."},
-                **_PROJECT_PARAM,
-            },
-        },
-    },
-    "memory_distill": {
-        "description": (
-        'MDL-based distillation: cluster similar obs into an abstraction + deltas.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "dry_run": {"type": "boolean", "description": "Preview (default true)."},
-                "min_cluster_size": {"type": "integer", "description": "Default 3."},
-                "compression_required": {"type": "number", "description": "Default 0.2."},
-                **_PROJECT_PARAM,
-            },
-        },
-    },
-    "memory_dedup_sweep": {
-        "description": (
-        'Backfill observations.content_hash (SHA256 of normalized content). Default: only NULL hashes.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "recompute": {"type": "boolean", "description": "Rehash every row, not just NULL (default false)."},
-                "batch_size": {"type": "integer", "description": "Commit cadence (default 500)."},
-                **_PROJECT_PARAM,
-            },
-        },
-    },
-    "memory_roi_gc": {
-        "description": (
-        'Archive observations whose ROI score falls below a threshold.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "dry_run": {"type": "boolean", "description": "Preview (default true)."},
-                "threshold": {"type": "number", "description": "Default 0.0."},
-                **_PROJECT_PARAM,
-            },
-        },
-    },
-    "memory_roi_stats": {
-        "description": (
-        'Token Economy ROI stats — net value by observation type.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {**_PROJECT_PARAM},
-        },
-    },
-    "memory_from_bash": {
-        "description": (
-        'Save a bash command as an observation (type=command, auto-extracted).'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "command": {"type": "string"},
-                "type": {"type": "string", "enum": ["command", "infra", "config"]},
-                "context": {"type": "string"},
-                **_PROJECT_PARAM,
-            },
-            "required": ["command"],
-        },
-    },
-    "memory_set_global": {
-        "description": (
-        "Set an observation's global visibility flag (is_global=True crosses all projects)."
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer", "description": "Observation ID"},
-                "is_global": {"type": "boolean", "description": "True=global, False=local"},
-            },
-            "required": ["id", "is_global"],
-        },
-    },
     "memory_search": {
         "description": (
         'Layer 2 FTS5 search over memory observations, compact rows with snippets (~60 tokens/result).'   ),
@@ -1010,18 +875,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
                 **_PROJECT_PARAM,
             },
             "required": ["query"],
-        },
-    },
-    "memory_session_history": {
-        "description": (
-        'Last N structured session-end rollups (request, investigated, learned, completed, next_steps, notes).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "limit": {"type": "integer", "description": "Default 10."},
-                **_PROJECT_PARAM,
-            },
         },
     },
     "memory_get": {
@@ -1083,57 +936,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "required": [],
         },
     },
-    "memory_timeline": {
-        "description": (
-        'Chronological context around an observation (before/after in time).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "observation_id": {
-                    "type": "integer",
-                    "description": "Center observation ID.",
-                },
-                "window": {
-                    "type": "integer",
-                    "description": "Window in hours around the observation (default 24).",
-                },
-                **_PROJECT_PARAM,
-            },
-            "required": ["observation_id"],
-        },
-    },
-    "memory_prompts": {
-        "description": (
-        'Save or search prompt history (archival of notable user prompts).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "action": {"type": "string", "enum": ["save", "search"], "description": "save or search"},
-                "prompt_text": {"type": "string", "description": "Prompt to save"},
-                "prompt_number": {"type": "integer", "description": "Prompt ordinal"},
-                "query": {"type": "string", "description": "Search query"},
-                "limit": {"type": "integer", "description": "Max results"},
-                **_PROJECT_PARAM,
-            },
-            "required": ["action"],
-        },
-    },
-    "memory_mode": {
-        "description": (
-        'Get or set the memory capture mode (code | review | debug | infra | silent).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "action": {"type": "string", "enum": ["get", "set", "set_project"], "description": "Action"},
-                "mode": {"type": "string", "enum": ["code", "review", "debug", "silent"], "description": "Mode name"},
-                "project": {"type": "string", "description": "Project path"},
-            },
-            "required": ["action"],
-        },
-    },
     "corpus_build": {
         "description": (
         'Build a thematic corpus from observations filtered by type / tags / symbol.'
@@ -1148,31 +950,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
                 **_PROJECT_PARAM,
             },
             "required": ["name"],
-        },
-    },
-    "memory_archive": {
-        "description": (
-        'Manage archived observations (list, undelete, purge).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "action": {"type": "string", "enum": ["run", "list", "restore"], "description": "run=decay, list, restore"},
-                "id": {"type": "integer", "description": "ID for restore"},
-                "dry_run": {"type": "boolean", "description": "Preview only"},
-                "limit": {"type": "integer", "description": "List max entries"},
-                **_PROJECT_PARAM,
-            },
-            "required": ["action"],
-        },
-    },
-    "memory_status": {
-        "description": (
-        'Memory Engine snapshot: active/archived counts, mode, last session, summaries.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {},
         },
     },
     # ── Program slicing & context packing (Phase 2) ───────────────────────
@@ -1246,40 +1023,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "required": ["name", "question"],
         },
     },
-    "memory_bus_push": {
-        "description": (
-        'Push a volatile observation to the inter-agent memory bus (tagged by agent_id).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "agent_id": {"type": "string"},
-                "title": {"type": "string"},
-                "content": {"type": "string"},
-                "type": {"type": "string", "description": "Default 'note'."},
-                "symbol": {"type": "string"},
-                "file_path": {"type": "string"},
-                "tags": {"type": "array", "items": {"type": "string"}},
-                "ttl_days": {"type": "integer", "description": "Default 1."},
-                **_PROJECT_PARAM,
-            },
-            "required": ["agent_id", "title", "content"],
-        },
-    },
-    "memory_bus_list": {
-        "description": (
-        'List recent live messages on the inter-agent memory bus, optionally filtered by agent_id.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "agent_id": {"type": "string", "description": "Filter by subagent id (optional)."},
-                "limit": {"type": "integer", "description": "Max rows (default 20)."},
-                "include_expired": {"type": "boolean", "description": "Show expired bus rows too."},
-                **_PROJECT_PARAM,
-            },
-        },
-    },
     "reasoning_save": {
         "description": (
         'Persist a reasoning trace (goal + steps + conclusion) for later reuse.'
@@ -1324,46 +1067,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "properties": {
                 "limit": {"type": "integer", "description": "Max rows (default 50)."},
                 **_PROJECT_PARAM,
-            },
-        },
-    },
-    "memory_consistency": {
-        "description": (
-        'Run Bayesian self-consistency check on symbol-linked obs (updates α/β; flags stale + quarantine).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "project_root": {
-                    "type": "string",
-                    "description": "Project filter; omit to run across all projects.",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max observations to check this pass (default 100).",
-                },
-                "dry_run": {
-                    "type": "boolean",
-                    "description": "Report what would change without persisting.",
-                },
-            },
-        },
-    },
-    "memory_quarantine_list": {
-        "description": (
-        'List observations quarantined by the consistency check (Bayesian validity < 40 %).'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "project_root": {
-                    "type": "string",
-                    "description": "Filter by project; omit for all projects.",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max rows to return (default 50).",
-                },
             },
         },
     },
@@ -1444,4 +1147,23 @@ TOOL_SCHEMAS: dict[str, dict] = {
             },
         },
     },
+    "memory_admin": {
+        "description": "Single dispatch for all memory admin / maintenance ops (status, doctor, dedup_sweep, distill, roi_gc, consistency, vector_reindex, etc.).",
+        "inputSchema": {
+            "type": "object",
+            "required": ["op"],
+            "properties": {
+                "op": {
+                    "type": "string",
+                    "enum": ["status", "top", "why", "timeline", "session_history", "prompts", "mode", "archive", "bus_push", "bus_list", "consistency", "quarantine_list", "maintain", "doctor", "vector_reindex", "distill", "dedup_sweep", "roi_gc", "roi_stats", "from_bash", "set_global"],
+                    "description": "Which memory-admin sub-operation to run.",
+                },
+                "project_root": {"type": "string", "description": "Filter by project (where applicable)."},
+                "limit": {"type": "integer", "description": "Pagination/limit (where applicable)."},
+                "dry_run": {"type": "boolean", "description": "Preview-only mode for sweeps/garbage collectors."},
+            },
+            "additionalProperties": True,
+        },
+    },
+
 }

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -67,19 +67,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             },
         },
     },
-    "summarize_patch_by_symbol": {
-        "description": (
-        'Symbol-level summary of a specific set of changed files.' ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "changed_files": {"type": "array", "items": {"type": "string"}},
-                "max_files": {"type": "integer", "description": "Default 20."},
-                "max_symbols_per_file": {"type": "integer", "description": "Default 20."},
-                **_PROJECT_PARAM,
-            },
-        },
-    },
     "build_commit_summary": {
         "description": (
         'Compact commit/review narrative with stats, hotspots, suggested type.'   ),
@@ -213,33 +200,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "required": ["model", "field_name", "field_type"],
         },
     },
-    "apply_refactoring": {
-        "description": (
-        'Polymorphic refactoring: rename, move, add_field, extract.'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": ["rename", "move", "add_field", "extract"],
-                    "description": "Refactoring operation type.",
-                },
-                "symbol": {"type": "string", "description": "Symbol name (rename/move)."},
-                "new_name": {"type": "string", "description": "New name (rename/extract)."},
-                "target_file": {"type": "string", "description": "Target file (move)."},
-                "create_if_missing": {"type": "boolean", "description": "Create target if missing (move, default true)."},
-                "model": {"type": "string", "description": "Model name (add_field)."},
-                "field_name": {"type": "string", "description": "Field name (add_field)."},
-                "field_type": {"type": "string", "description": "Field type (add_field)."},
-                "file_path": {"type": "string", "description": "File path (extract/add_field)."},
-                "after": {"type": "string", "description": "Insert after (add_field)."},
-                "start_line": {"type": "integer", "description": "Start line (extract)."},
-                "end_line": {"type": "integer", "description": "End line (extract)."},
-                **_PROJECT_PARAM,
-            },
-            "required": ["type"],
-        },
-    },
     # ── Tests & validation ────────────────────────────────────────────────
     "find_impacted_test_files": {
         "description": (
@@ -269,26 +229,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
                 "compact": {"type": "boolean"},
                 **_PROJECT_PARAM,
             },
-        },
-    },
-    "apply_symbol_change_and_validate": {
-        "description": (
-        'Replace symbol source, reindex, run impacted tests in one call.'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "symbol_name": {"type": "string"},
-                "new_source": {"type": "string"},
-                "file_path": {"type": "string"},
-                "rollback_on_failure": {"type": "boolean"},
-                "max_tests": {"type": "integer"},
-                "timeout_sec": {"type": "integer"},
-                "max_output_chars": {"type": "integer"},
-                "include_output": {"type": "boolean"},
-                "compact": {"type": "boolean"},
-                **_PROJECT_PARAM,
-            },
-            "required": ["symbol_name", "new_source"],
         },
     },
     # ── Project actions ───────────────────────────────────────────────────
@@ -756,24 +696,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "required": ["var_name"],
         },
     },
-    "get_components": {
-        "description": (
-        'Detect React components in .tsx/.jsx: pages, layouts, named (uppercase) and default exports.'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "file_path": {
-                    "type": "string",
-                    "description": "Optional file to scan (default: all .tsx/.jsx).",
-                },
-                "max_results": {
-                    "type": "integer",
-                    "description": "Max results (0 = all, default 0).",
-                },
-                **_PROJECT_PARAM,
-            },
-        },
-    },
     # ── Analysis tools ────────────────────────────────────────────────────
     "analyze_config": {
         "description": (
@@ -846,14 +768,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             },
         },
     },
-    "find_cross_project_deps": {
-        "description": (
-        'Dependencies between indexed projects: which project imports packages from other indexed projects.'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {},
-        },
-    },
     "analyze_docker": {
         "description": (
         'Audit Dockerfiles: base images, stages, exposed ports, ENV/ARG, cross-ref with config files.'   ),
@@ -888,106 +802,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
             },
         },
     },
-    "get_library_symbol": {
-        "description": (
-        'Resolve a library symbol (npm .d.ts or Python module): signature, JSDoc/docstring, source location.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "package": {
-                    "type": "string",
-                    "description": "npm package name (e.g. '@supabase/supabase-js') or Python module (e.g. 'pandas').",
-                },
-                "symbol_path": {
-                    "type": "string",
-                    "description": "Dotted symbol path inside the package (e.g. 'createClient', 'SupabaseAuthClient.signInWithOtp').",
-                },
-                "max_files": {
-                    "type": "integer",
-                    "description": "Cap on .d.ts files scanned (default 200).",
-                },
-                **_PROJECT_PARAM,
-            },
-            "required": ["package"],
-        },
-    },
-    "list_library_symbols": {
-        "description": (
-        'List top-level exports of an installed library (.d.ts or Python module), optionally regex-filtered.' ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "package": {
-                    "type": "string",
-                    "description": "npm package name or Python module.",
-                },
-                "pattern": {
-                    "type": "string",
-                    "description": "Case-insensitive regex filter on symbol names (optional).",
-                },
-                "max_files": {
-                    "type": "integer",
-                    "description": "Cap on .d.ts files scanned (default 100).",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Cap on results (default 100).",
-                },
-                **_PROJECT_PARAM,
-            },
-            "required": ["package"],
-        },
-    },
-    "find_library_symbol_by_description": {
-        "description": (
-        "Rank a package's exports by Nomic-embedding similarity to a NL description. On-the-fly, no persistent index."
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "package": {
-                    "type": "string",
-                    "description": "npm package name or Python module.",
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Natural-language description of what the symbol does.",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Top-K hits to return (default 10).",
-                },
-                "max_files": {
-                    "type": "integer",
-                    "description": "Cap on .d.ts files scanned (default 100).",
-                },
-                "candidate_pool": {
-                    "type": "integer",
-                    "description": "Max exports considered before ranking (default 200).",
-                },
-                **_PROJECT_PARAM,
-            },
-            "required": ["package", "description"],
-        },
-    },
-    "audit_file": {
-        "description": (
-        'Mega-batch audit of a single file: dead_code + hotspots + semantic duplicates in one call.'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "file_path": {"type": "string", "description": "Relative path of the file to audit."},
-                "max_dead": {"type": "integer", "description": "Cap on dead-code scan (default 50)."},
-                "max_hotspots": {"type": "integer", "description": "Cap on hotspot scan (default 50)."},
-                "min_score": {"type": "number", "description": "Minimum complexity score (default 0)."},
-                "min_lines": {"type": "integer", "description": "Semantic-dup min length (default 6)."},
-                "max_dup_groups": {"type": "integer", "description": "Semantic-dup group cap (default 20)."},
-                **_PROJECT_PARAM,
-            },
-            "required": ["file_path"],
-        },
-    },
     "get_entry_points": {
         "description": (
         'Score functions by likelihood of being execution entry points: routes, handlers, main, exported APIs.' ),
@@ -998,71 +812,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
                     "type": "integer",
                     "description": "Maximum number of entry points to return (default 20).",
                 },
-                **_PROJECT_PARAM,
-            },
-        },
-    },
-    "get_related_symbols": {
-        "description": (
-        'Related-symbols query. method = community | rwr | cluster | coactive.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "method": {
-                    "type": "string",
-                    "enum": ["community", "rwr", "cluster", "coactive"],
-                    "description": "Algorithm (default 'community').",
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Seed symbol. Required for rwr/cluster/coactive; optional for community when list_all=true.",
-                },
-                "max_members": {
-                    "type": "integer",
-                    "description": "cluster: max members (default 30).",
-                },
-                "budget": {
-                    "type": "integer",
-                    "description": "rwr: top-K symbols (default 10).",
-                },
-                "include_reverse": {
-                    "type": "boolean",
-                    "description": "rwr: include reverse-dependency edges (default true).",
-                },
-                "top_k": {
-                    "type": "integer",
-                    "description": "coactive: max results (default 5).",
-                },
-                "community_name": {
-                    "type": "string",
-                    "description": "community: look up by community name instead of seed symbol.",
-                },
-                "list_all": {
-                    "type": "boolean",
-                    "description": "community: enumerate all communities (default false).",
-                },
-                "min_size": {
-                    "type": "integer",
-                    "description": "community+list_all: min members (default 2).",
-                },
-                "max_results": {
-                    "type": "integer",
-                    "description": "community+list_all: max communities (default 30).",
-                },
-                **_PROJECT_PARAM,
-            },
-        },
-    },
-    "get_duplicate_classes": {
-        "description": (
-        'Find Java classes duplicated across files (by FQN or simple name).'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string", "description": "Filter class."},
-                "simple_name_mode": {"type": "boolean", "description": "Group by simple name."},
-                "max_results": {"type": "integer", "description": "0=all."},
                 **_PROJECT_PARAM,
             },
         },
@@ -1427,29 +1176,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
         },
     },
     # ── Program slicing & context packing (Phase 2) ───────────────────────
-    "verify_edit": {
-        "description": (
-        'EditSafety certificate — static analysis before a symbol replacement: signature, exceptions, side-effects, test impact.'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "symbol_name": {
-                    "type": "string",
-                    "description": "Symbol that would be replaced.",
-                },
-                "new_source": {
-                    "type": "string",
-                    "description": "Proposed replacement source.",
-                },
-                "file_path": {
-                    "type": "string",
-                    "description": "Optional file path to disambiguate the symbol.",
-                },
-                **_PROJECT_PARAM,
-            },
-            "required": ["symbol_name", "new_source"],
-        },
-    },
     "find_semantic_duplicates": {
         "description": (
         "Find duplicate functions. method='ast' (fast, hash-based, catches copy-paste) or 'embedding' (Nomic cosine, catches conceptual clones, tagged sim=min..mean per cluster)."
@@ -1498,58 +1224,6 @@ TOOL_SCHEMAS: dict[str, dict] = {
                 },
                 **_PROJECT_PARAM,
             },
-        },
-    },
-    "get_call_predictions": {
-        "description": (
-        'Predict next-likely tool calls from a first-order Markov model trained on prior sessions.'
-    ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "tool_name": {
-                    "type": "string",
-                    "description": "Current tool name (e.g. 'get_function_source').",
-                },
-                "symbol_name": {
-                    "type": "string",
-                    "description": "Optional current symbol focus (e.g. 'observation_save').",
-                },
-                "top_k": {
-                    "type": "integer",
-                    "description": "Maximum number of predictions to return (default 5).",
-                },
-            },
-            "required": ["tool_name"],
-        },
-    },
-    "pack_context": {
-        "description": (
-        'Knapsack-packed context bundle for a query within a token budget.'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string"},
-                "budget_tokens": {"type": "integer", "description": "Default 4000."},
-                "max_symbols": {"type": "integer", "description": "Default 20."},
-                **_PROJECT_PARAM,
-            },
-            "required": ["query"],
-        },
-    },
-    "get_backward_slice": {
-        "description": (
-        'Minimal lines affecting a variable at a given line inside a symbol.'   ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string"},
-                "variable": {"type": "string"},
-                "line": {"type": "integer", "description": "1-based."},
-                "file_path": {"type": "string"},
-                **_PROJECT_PARAM,
-            },
-            "required": ["name", "variable", "line"],
         },
     },
     "corpus_query": {

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -65,7 +65,14 @@ class TestToolSchemas:
         #   verbose tool outputs, response to mksglu/context-mode) = 100.
         # +1 edit_lines_in_symbol (symbol-scoped string-replace, captures the
         #   80%+ of native Edit calls landing on indexed code files) = 101.
-        assert len(TOOL_SCHEMAS) == 101, f"Expected 101 tools, got {len(TOOL_SCHEMAS)}"
+        # -15 round-3 dead-tool removal (apply_refactoring, apply_symbol_change_and_validate,
+        #   audit_file, verify_edit, find_cross_project_deps,
+        #   find_library_symbol_by_description, get_backward_slice,
+        #   get_call_predictions, get_components, get_duplicate_classes,
+        #   get_library_symbol, get_related_symbols, list_library_symbols,
+        #   pack_context, summarize_patch_by_symbol — 0 prod calls in 30 d
+        #   and no marginal value) = 86.
+        assert len(TOOL_SCHEMAS) == 86, f"Expected 86 tools, got {len(TOOL_SCHEMAS)}"
 
     def test_server_tools_match_schemas(self):
         from token_savior.server import TOOLS

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -72,7 +72,13 @@ class TestToolSchemas:
         #   get_library_symbol, get_related_symbols, list_library_symbols,
         #   pack_context, summarize_patch_by_symbol — 0 prod calls in 30 d
         #   and no marginal value) = 86.
-        assert len(TOOL_SCHEMAS) == 86, f"Expected 86 tools, got {len(TOOL_SCHEMAS)}"
+        # -21 round-5 memory_admin fusion (memory_status / top / why / timeline /
+        #   session_history / prompts / mode / archive / bus_push / bus_list /
+        #   consistency / quarantine_list / maintain / doctor / vector_reindex /
+        #   distill / dedup_sweep / roi_gc / roi_stats / from_bash / set_global
+        #   collapsed into a single memory_admin(op=...) dispatcher) = 65.
+        # +1 memory_admin (the fusion itself) = 66.
+        assert len(TOOL_SCHEMAS) == 66, f"Expected 66 tools, got {len(TOOL_SCHEMAS)}"
 
     def test_server_tools_match_schemas(self):
         from token_savior.server import TOOLS


### PR DESCRIPTION
## Summary

Two cleanup rounds in one PR :

* **Round 3** — physically delete 15 dead-on-arrival tools (0 prod calls, 0 bench calls).
* **Round 5** — fuse 21 memory admin/maintenance tools into a single ``memory_admin(op=...)`` dispatcher.

Combined : full profile **13 397 → 8 969 tokens (-33 %)**, codebase **-1 000 LOC**, 36 tool schemas removed.

## Round 3 — physical removal (15 tools)

| Category | Tools |
|---|---|
| Composites overlapping primitives | `apply_refactoring`, `apply_symbol_change_and_validate`, `audit_file`, `verify_edit` |
| Niche analysis (0 calls) | `get_backward_slice`, `get_call_predictions`, `get_components`, `get_duplicate_classes`, `get_related_symbols`, `summarize_patch_by_symbol`, `find_cross_project_deps`, `pack_context` |
| Library API (0 calls) | `find_library_symbol_by_description`, `get_library_symbol`, `list_library_symbols` |

Schemas removed via AST splice, dispatch entries removed from each handler module, orphan handler functions deleted, dead imports cleaned. Underlying source modules kept (their direct-import tests still pass).

## Round 5 — memory admin fusion (21 → 1)

The 21 admin tools (status / top / why / timeline / session_history / prompts / mode / archive / bus_push / bus_list / consistency / quarantine_list / maintain / doctor / vector_reindex / distill / dedup_sweep / roi_gc / roi_stats / from_bash / set_global) were already lean-excluded but still cost ~1 700 tokens on the full manifest.

Replaced by ``memory_admin(op="<sub-op>")`` dispatcher routing to existing handlers. All 21 ops still reachable, schemas collapsed to 1 enum.

User-facing memory tools stay separate : `memory_save`, `memory_search`, `memory_index`, `memory_get`, `memory_delete`.

## Manifest impact

| Profile | Pre-PR | Post-PR | Δ |
|---|---:|---:|---:|
| full | 13 397 | **8 969** | **-33 %** |
| lean+memdis | 6 740 | 6 740 | 0 (already lean) |
| ultra | 3 002 | 2 834 | -6 % |

## Tests

**1 441 passed, 4 skipped, 0 failed.** ``test_tool_count`` bumped 101 → 66 with a full inline log of what was removed/fused and why.

## Why no Round 4

Audit identified 4 candidate fusions (analyze_deps, analyze_file_deps, list_symbols, analyze_quality). Skipped because the primitives are HOT in production (get_dependents 17 prod calls, get_functions 58, find_dead_code 18) and adding fusion alongside them grows full manifest. Pure-fusion replacement would risk breaking established agent patterns mid-stream. Better: defer to a v3 release with proper migration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)