### PR TITLE
revert(round-6): keep 'full' as default profile

### DIFF
--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -203,13 +203,13 @@ _PROFILE_EXCLUDES: dict[str, set[str]] = {
     "ultra": set(TOOL_SCHEMAS) - _ULTRA_INCLUDES,
 }
 
-_PROFILE = os.environ.get("TOKEN_SAVIOR_PROFILE", "ultra").lower()
+_PROFILE = os.environ.get("TOKEN_SAVIOR_PROFILE", "full").lower()
 if _PROFILE not in _PROFILE_EXCLUDES:
     print(
-        f"[token-savior] unknown profile '{_PROFILE}', using ultra",
+        f"[token-savior] unknown profile '{_PROFILE}', using full",
         file=sys.stderr,
     )
-    _PROFILE = "ultra"
+    _PROFILE = "full"
 
 _HIDDEN_UNDER_ULTRA: set[str] = _PROFILE_EXCLUDES["ultra"]
 
@@ -267,16 +267,13 @@ print(
     file=sys.stderr,
 )
 
-# v3 default flip: ultra is now the default. The expanded ultra profile
-# (33 tools + ts_extended proxy) covers the production hot path while
-# keeping the manifest under 5 k tokens. Users who script against the
-# full surface (CI, batch tooling) can opt in via
-# TOKEN_SAVIOR_PROFILE=full or =lean.
-if "TOKEN_SAVIOR_PROFILE" not in os.environ:
+# Default stays at 'full' (66 tools, ~9k tokens). Token-conscious users
+# can opt down via TOKEN_SAVIOR_PROFILE=lean (51 tools), =ultra (33 hot
+# tools + ts_extended proxy, ~5k tokens), =core, or =nav.
+if "TOKEN_SAVIOR_PROFILE" not in os.environ and _PROFILE == "full":
     print(
-        "[token-savior] default profile is now 'ultra' (33 hot tools + "
-        "ts_extended proxy). Set TOKEN_SAVIOR_PROFILE=lean for the broader "
-        "lean surface, or =full for everything.",
+        "[token-savior] profile=full (66 tools). Set TOKEN_SAVIOR_PROFILE=lean "
+        "or =ultra to reduce manifest cost.",
         file=sys.stderr,
     )
 

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -37,16 +37,12 @@ def test_full_profile_exposes_all_tools(monkeypatch):
     assert len(srv.TOOLS) == _TOTAL
 
 
-def test_unset_defaults_to_ultra(monkeypatch):
-    """Default flipped from 'full' to 'ultra' in v3 (Round 6 cleanup)."""
+def test_unset_defaults_to_full(monkeypatch):
+    """Default profile is 'full' (66 tools). Reverted from the brief Round-6
+    ultra-default experiment per user preference. ultra and lean remain
+    opt-in via TOKEN_SAVIOR_PROFILE."""
     srv = _reload_with_profile(monkeypatch, None)
-    # ultra exposes a curated 33-tool subset + the ts_extended proxy.
-    # The exact count depends on _ULTRA_INCLUDES; just verify it's
-    # significantly smaller than full and contains ts_extended.
-    names = {t.name for t in srv.TOOLS}
-    assert len(names) < _TOTAL
-    assert "ts_extended" in names
-    assert "find_symbol" in names  # canary: a hot tool stays visible
+    assert len(srv.TOOLS) == _TOTAL
 
 
 def test_core_profile_excludes_memory_and_meta(monkeypatch):
@@ -69,12 +65,9 @@ def test_nav_profile_is_subset_of_core(monkeypatch):
     assert nav_names == set(QFN_HANDLERS)
 
 
-def test_invalid_profile_falls_back_to_ultra(monkeypatch, capsys):
+def test_invalid_profile_falls_back_to_full(monkeypatch, capsys):
     srv = _reload_with_profile(monkeypatch, "bogus")
-    # Falls back to the new default (ultra) — see test_unset_defaults_to_ultra.
-    names = {t.name for t in srv.TOOLS}
-    assert len(names) < _TOTAL
-    assert "ts_extended" in names
+    assert len(srv.TOOLS) == _TOTAL
     err = capsys.readouterr().err
     assert "unknown profile 'bogus'" in err
 

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -81,17 +81,10 @@ class TestToolSchemas:
         assert len(TOOL_SCHEMAS) == 66, f"Expected 66 tools, got {len(TOOL_SCHEMAS)}"
 
     def test_server_tools_match_schemas(self):
-        """Default profile is now 'ultra' which is a strict subset of TOOL_SCHEMAS,
-        plus the synthetic 'ts_extended' proxy. Verify the structural relation
-        rather than equality."""
         from token_savior.server import TOOLS
         server_names = {t.name for t in TOOLS}
         schema_names = set(TOOL_SCHEMAS.keys())
-        # All advertised tools must either be a real schema OR the synthetic
-        # ts_extended proxy that ultra adds at runtime.
-        assert server_names <= (schema_names | {"ts_extended"})
-        # ts_extended is mandatory under ultra — sanity check.
-        assert "ts_extended" in server_names
+        assert server_names == schema_names
 
 
 class TestV2HandlersRemoved:


### PR DESCRIPTION
## Summary

PR [#24](https://github.com/Mibayy/token-savior/pull/24) flipped the default to `ultra`. Reverting that decision per user preference — `full` stays the default. The expanded ultra profile (33 tools curated from 30 d production audit) stays available as opt-in via `TOKEN_SAVIOR_PROFILE=ultra`.

## What this changes

- Default profile back to `full` (66 tools, ~9k tokens manifest)
- Boot warning re-enabled for the `full` profile (suggests opt-in to lean/ultra)
- 3 tests reverted to their pre-#24 names + assertions

## What stays from #24

- The expanded `_ULTRA_INCLUDES` set (33 tools, was 17). Whoever opts into ultra still benefits from the broader curated surface.

## Tests

1 441 passed, 4 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)