### PR TITLE
fix(indexer): catch annotator exceptions per file (closes #26)

### DIFF
--- a/src/token_savior/project_indexer.py
+++ b/src/token_savior/project_indexer.py
@@ -292,7 +292,16 @@ class ProjectIndexer:
             except (OSError, UnicodeDecodeError) as e:
                 logger.warning("Skipping %s: %s", rel_path, e)
                 return None
-            metadata = annotate(source, source_name=rel_path)
+            try:
+                metadata = annotate(source, source_name=rel_path)
+            except Exception as e:
+                logger.warning(
+                    "Annotator failed on %s (%s: %s); skipping symbols for this file",
+                    rel_path,
+                    type(e).__name__,
+                    e,
+                )
+                return None
             fill_hashes(metadata, source.splitlines())
             return rel_path, metadata, mtime
 
@@ -427,7 +436,21 @@ class ProjectIndexer:
                 _rebuild_path_indexes(idx)
             return
 
-        metadata = annotate(source, source_name=rel_path)
+        try:
+            metadata = annotate(source, source_name=rel_path)
+        except Exception as e:
+            logger.warning(
+                "Annotator failed on %s (%s: %s); dropping from index",
+                rel_path,
+                type(e).__name__,
+                e,
+            )
+            if rel_path in idx.files:
+                del idx.files[rel_path]
+                idx.file_mtimes.pop(rel_path, None)
+                idx.total_files = len(idx.files)
+                _rebuild_path_indexes(idx)
+            return
         fill_hashes(metadata, source.splitlines())
 
         # Symbol-level diffing: count what actually changed vs the old hashes.

--- a/tests/test_project_indexer.py
+++ b/tests/test_project_indexer.py
@@ -656,6 +656,112 @@ class TestGoProject:
         assert "App.Run" in idx.symbol_table
 
 
+@pytest.fixture
+def java_project(tmp_path):
+    """Create a small Java project for end-to-end indexer regression tests."""
+    root = tmp_path / "javaproject"
+    pkg = root / "src" / "main" / "java" / "com" / "example"
+    pkg.mkdir(parents=True)
+
+    (pkg / "Calculator.java").write_text(
+        textwrap.dedent("""\
+        package com.example;
+
+        import java.util.ArrayList;
+        import java.util.List;
+
+        /** A toy calculator. */
+        public class Calculator {
+            private final List<Integer> history = new ArrayList<>();
+
+            public int add(int a, int b) {
+                int result = a + b;
+                history.add(result);
+                return result;
+            }
+
+            public int sub(int a, int b) {
+                return a - b;
+            }
+        }
+        """)
+    )
+
+    (pkg / "Main.java").write_text(
+        textwrap.dedent("""\
+        package com.example;
+
+        public class Main {
+            public static void main(String[] args) {
+                Calculator c = new Calculator();
+                System.out.println(c.add(1, 2));
+            }
+        }
+        """)
+    )
+
+    return root
+
+
+class TestJavaProject:
+    """Regression coverage for issue #26: default Java indexing must work
+    end-to-end through the public ProjectIndexer entry point with no
+    explicit include_patterns override."""
+
+    def test_default_include_patterns_pick_up_java(self, java_project):
+        # No include_patterns override: must rely on the indexer defaults.
+        idx = ProjectIndexer(str(java_project)).index()
+        java_files = [f for f in idx.files if f.endswith(".java")]
+        assert len(java_files) == 2
+
+    def test_default_indexer_dispatches_java_to_annotator(self, java_project):
+        idx = ProjectIndexer(str(java_project)).index()
+        # If .java were not dispatched to annotate_java, both files would
+        # fall through to the generic line-only annotator and produce
+        # zero functions / zero classes.
+        assert idx.total_functions >= 3  # add, sub, main
+        assert idx.total_classes >= 2  # Calculator, Main
+
+    def test_java_symbols_in_global_table(self, java_project):
+        idx = ProjectIndexer(str(java_project)).index()
+        assert "Calculator" in idx.symbol_table
+        assert "Main" in idx.symbol_table
+        assert "Calculator.add" in idx.symbol_table
+        assert "Calculator.sub" in idx.symbol_table
+
+
+class TestAnnotatorResilience:
+    """Regression coverage for issue #26: a single broken annotator call
+    must not abort the whole index — only that file should be skipped."""
+
+    def test_annotator_failure_skips_file_but_continues_index(
+        self, tmp_path, monkeypatch
+    ):
+        # Lay out a project with one .py and one .java file.
+        (tmp_path / "ok.py").write_text("def good():\n    return 1\n")
+        (tmp_path / "boom.java").write_text("class Boom {}\n")
+
+        from token_savior import project_indexer as pi
+
+        real_annotate = pi.annotate
+
+        def flaky_annotate(text, source_name="<source>", file_type=None):
+            if source_name.endswith(".java"):
+                raise RuntimeError("synthetic annotator failure")
+            return real_annotate(text, source_name, file_type)
+
+        monkeypatch.setattr(pi, "annotate", flaky_annotate)
+
+        idx = ProjectIndexer(str(tmp_path)).index()
+
+        # The Python file is still indexed, the Java file is dropped silently.
+        py_files = [f for f in idx.files if f.endswith(".py")]
+        java_files = [f for f in idx.files if f.endswith(".java")]
+        assert len(py_files) == 1
+        assert len(java_files) == 0
+        assert "good" in idx.symbol_table
+
+
 class TestRustProject:
     def test_discovers_rust_files(self, rust_project):
         indexer = ProjectIndexer(


### PR DESCRIPTION
## Summary
- Wrap the `annotate(...)` call in `ProjectIndexer.index()` and `reindex_file()` with an explicit Exception handler so a single broken file (Java parse edge case, missing tree-sitter binding on Windows, encoding glitch, etc.) gets logged and skipped instead of poisoning the whole index.
- Add `TestJavaProject` end-to-end coverage that uses **default** include_patterns (no overrides) to confirm `.java` is picked up, dispatched to `annotate_java`, and yields functions / classes / symbol-table entries.
- Add `TestAnnotatorResilience` to assert that an annotator raising on one file does not stop the rest of the index.

## Context for issue #26
Investigation showed the source already includes `**/*.java` in default patterns (`project_indexer.py`), dispatches `.java` to `annotate_java` (`annotator.py`), and ships every field `java_annotator.py` expects (`build_line_char_offsets`, `decorator_details`, `visibility`, `return_type`, `module_name`). A fresh repro on `/tmp/java_test/Calculator.java` indexes 2 functions / 1 class as expected.

The reporter's PyPI install is most likely **v2.6.0** (latest on PyPI) while the repo is on `v2.8.4` / `__version__ = "3.0.0"`. The right user-facing fix is a fresh release; this PR makes the indexer resilient against the underlying class of failure that produced the symptom and locks in a regression test for the default Java path.

## Test plan
- [x] `pytest tests/test_project_indexer.py -q` — 50 passed
- [x] Full suite (`pytest -q`, minus 2 pre-existing failures unrelated to this branch) — 1393 passed, 54 skipped