### PR TITLE
feat(server): opt-in MCP request lifecycle logging (#27)

### DIFF
--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 import traceback
 from typing import Any
 
@@ -574,18 +575,45 @@ def _handle_ts_extended(arguments: dict[str, Any]) -> list[types.TextContent]:
     )]
 
 
+# Request lifecycle logging is opt-in via TOKEN_SAVIOR_TRACE=1.
+# Issue #27: gives operators (especially on Windows where MCP requests
+# can hang or abort) a way to see start / dispatch / complete events
+# without enabling the full debug logger.
+_TRACE_REQUESTS = os.environ.get("TOKEN_SAVIOR_TRACE", "").lower() in ("1", "true", "yes")
+
+
 @server.call_tool()
 async def call_tool(name: str, arguments: dict[str, Any]) -> list[types.TextContent]:
+
+    start = time.monotonic() if _TRACE_REQUESTS else 0.0
+    if _TRACE_REQUESTS:
+        print(f"[token-savior] -> call {name}", file=sys.stderr, flush=True)
 
     record_symbol = _track_call(name, arguments)
     try:
         if name == "ts_extended":
-            return _handle_ts_extended(arguments)
-        if name == "ts_search":
-            return _handle_ts_search(arguments)
-        return _dispatch_tool(name, arguments, record_symbol)
+            result = _handle_ts_extended(arguments)
+        elif name == "ts_search":
+            result = _handle_ts_search(arguments)
+        else:
+            result = _dispatch_tool(name, arguments, record_symbol)
+        if _TRACE_REQUESTS:
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+            print(
+                f"[token-savior] <- ok   {name} ({elapsed_ms:.0f}ms)",
+                file=sys.stderr,
+                flush=True,
+            )
+        return result
 
     except Exception as e:
+        if _TRACE_REQUESTS:
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+            print(
+                f"[token-savior] <- err  {name} ({elapsed_ms:.0f}ms) {type(e).__name__}: {e}",
+                file=sys.stderr,
+                flush=True,
+            )
         print(f"[token-savior] Error in {name}: {traceback.format_exc()}", file=sys.stderr)
         return [TextContent(type="text", text=f"Error: {e}")]
 
@@ -596,8 +624,14 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[types.TextCont
 
 
 async def main():
+    if _TRACE_REQUESTS:
+        print("[token-savior] startup: running memory migrations", file=sys.stderr, flush=True)
     memory_db.run_migrations()
+    if _TRACE_REQUESTS:
+        print("[token-savior] startup: opening stdio transport", file=sys.stderr, flush=True)
     async with stdio_server() as (read_stream, write_stream):
+        if _TRACE_REQUESTS:
+            print("[token-savior] startup: server.run loop entered", file=sys.stderr, flush=True)
         await server.run(
             read_stream,
             write_stream,

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -214,3 +214,52 @@ class TestSessionResultCache:
             assert s._src_hits == hits_before
         finally:
             _cleanup_slot(root)
+
+
+class TestRequestTracing:
+    """Coverage for issue #27: TOKEN_SAVIOR_TRACE=1 emits stderr lifecycle
+    events around every MCP tool call so users on platforms with timing-
+    sensitive transports (Windows stdio, slow bridges) can correlate hangs
+    with concrete request boundaries."""
+
+    def test_trace_disabled_by_default_emits_nothing(self, tmp_path, capsys, monkeypatch):
+        # Force a clean reload of the module-level _TRACE_REQUESTS flag.
+        monkeypatch.delenv("TOKEN_SAVIOR_TRACE", raising=False)
+        import importlib
+        from token_savior import server as srv
+
+        importlib.reload(srv)
+
+        root = _setup_project(tmp_path)
+        try:
+            _run(srv.call_tool("set_project_root", {"path": root}))
+            _run(srv.call_tool("find_symbol", {"name": "hello"}))
+        finally:
+            _cleanup_slot(root)
+
+        err = capsys.readouterr().err
+        assert "[token-savior] -> call" not in err
+        assert "[token-savior] <- ok" not in err
+
+    def test_trace_enabled_logs_start_and_complete(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setenv("TOKEN_SAVIOR_TRACE", "1")
+        import importlib
+        from token_savior import server as srv
+
+        importlib.reload(srv)
+
+        root = _setup_project(tmp_path)
+        try:
+            _run(srv.call_tool("set_project_root", {"path": root}))
+            _run(srv.call_tool("find_symbol", {"name": "hello"}))
+        finally:
+            _cleanup_slot(root)
+            # Reset module so other tests don't see TRACE behaviour.
+            monkeypatch.delenv("TOKEN_SAVIOR_TRACE", raising=False)
+            importlib.reload(srv)
+
+        err = capsys.readouterr().err
+        assert "[token-savior] -> call set_project_root" in err
+        assert "[token-savior] <- ok   set_project_root" in err
+        assert "[token-savior] -> call find_symbol" in err
+        assert "[token-savior] <- ok   find_symbol" in err


### PR DESCRIPTION
## Summary
Issue #27 reports MCP requests aborting or hanging on Windows with no way to see what the server is doing. This PR adds an opt-in trace mode (`TOKEN_SAVIOR_TRACE=1`) that prints lifecycle events to stderr:

- `call_tool` logs `-> call <name>` on entry and `<- ok / err <name> (Nms)` on exit, with `flush=True` so events surface immediately in MCP client logs.
- `main()` logs three startup checkpoints (migrations, stdio open, server.run loop entered) so users can pinpoint whether a hang is in pre-loop setup or after the first dispatch.

Default behaviour is unchanged — no extra stderr noise unless the env var is set. The reporter on issue #27 will be able to share trace output and we (or they) can localise the abort to a concrete request.

## Test plan
- [x] `pytest tests/test_server_integration.py::TestRequestTracing -v` — both cases pass (default-off and explicit-on).
- [x] Full suite (`pytest -q`, minus 2 pre-existing failures unrelated to this branch) — 1391 passed, 54 skipped.