### PR TITLE
chore(tests): bump tool count to 67 + accept ts_search in nav profile

### DIFF
--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -62,7 +62,10 @@ def test_nav_profile_is_subset_of_core(monkeypatch):
     srv_nav = _reload_with_profile(monkeypatch, "nav")
     nav_names = {t.name for t in srv_nav.TOOLS}
     assert nav_names < core_names
-    assert nav_names == set(QFN_HANDLERS)
+    # nav = QFN handlers + ts_search (the discovery tool sits outside the
+    # handler groups but is intentionally exposed in nav so a stripped
+    # session can still reach hidden tools).
+    assert nav_names == set(QFN_HANDLERS) | {"ts_search"}
 
 
 def test_invalid_profile_falls_back_to_full(monkeypatch, capsys):

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -78,7 +78,9 @@ class TestToolSchemas:
         #   distill / dedup_sweep / roi_gc / roi_stats / from_bash / set_global
         #   collapsed into a single memory_admin(op=...) dispatcher) = 65.
         # +1 memory_admin (the fusion itself) = 66.
-        assert len(TOOL_SCHEMAS) == 66, f"Expected 66 tools, got {len(TOOL_SCHEMAS)}"
+        # +1 ts_search (v2.9 defer-loading discovery tool — exposed as a
+        #   schema entry so it appears in lean/nav manifests) = 67.
+        assert len(TOOL_SCHEMAS) == 67, f"Expected 67 tools, got {len(TOOL_SCHEMAS)}"
 
     def test_server_tools_match_schemas(self):
         from token_savior.server import TOOLS


### PR DESCRIPTION
## Summary
Fixes two stale assertions that have been failing on main since v2.9 introduced \`ts_search\`:
- \`test_nav_profile_is_subset_of_core\` — nav legitimately contains \`ts_search\` (discovery tool sits outside the QFN/MEMORY/META/SLOT groups by design so stripped profiles can still reach hidden tools). Updated to \`set(QFN_HANDLERS) | {"ts_search"}\`.
- \`test_tool_count\` — hard-coded count was 66 but current TOOL_SCHEMAS = 67. Bumped with a comment line documenting the addition.

Test-only change. Unblocks CI on PRs #28 and #29.

## Test plan
- [x] \`pytest tests/test_server_tools.py tests/test_tool_schemas.py -q\` — 13 passed
- [x] Full suite \`pytest -q\` — 1391 passed, 54 skipped (no failures)