### PR TITLE
fix(cli): JSON-escape TS_HOOKS_DIR substitution so `ts init` works on Windows

### DIFF
--- a/src/token_savior/cli_init/__init__.py
+++ b/src/token_savior/cli_init/__init__.py
@@ -95,6 +95,7 @@ def _load_hook_bundles(agent: str, ts_root: Path) -> list[dict]:
     """Load shipped hook JSON configs and substitute the {{TS_HOOKS_DIR}}
     placeholder with the actual install path of this Token Savior copy."""
     hooks_dir = str((ts_root / "hooks").resolve())
+    hooks_dir_json = json.dumps(hooks_dir)[1:-1]
     bundles: list[dict] = []
     missing: list[Path] = []
     for p in hook_config_paths(agent, ts_root):
@@ -102,7 +103,7 @@ def _load_hook_bundles(agent: str, ts_root: Path) -> list[dict]:
             missing.append(p)
             continue
         try:
-            raw = p.read_text(encoding="utf-8").replace("{{TS_HOOKS_DIR}}", hooks_dir)
+            raw = p.read_text(encoding="utf-8").replace("{{TS_HOOKS_DIR}}", hooks_dir_json)
             bundles.append(json.loads(raw))
         except (OSError, json.JSONDecodeError) as e:
             raise RuntimeError(f"cannot load bundled hook config {p}: {e}") from e


### PR DESCRIPTION
## Summary

`ts init` is currently unusable on Windows for every supported agent (claude, cursor, gemini, codex). Root cause is in `_load_hook_bundles` (`src/token_savior/cli_init/__init__.py`).

## Problem

The function substitutes the `{{TS_HOOKS_DIR}}` placeholder into shipped hook configs by a plain string replace, then runs `json.loads` on the result. The placeholder sits inside a JSON string literal:

```json
"command": "/usr/bin/python3 {{TS_HOOKS_DIR}}/tool_capture_hook.py"
```

On POSIX the resolved path has no characters that need JSON-escaping, so this works. On Windows the resolved path looks like

```
E:\Misc\repo\token-savior\hooks
```

and the unescaped backslashes produce invalid `\escape` sequences inside the JSON string, making `json.loads` raise:

```
JSONDecodeError: Invalid \escape: ...
```

Reproduced locally — without the fix, `_load_hook_bundles` raises for **all 4** supported agents.

## Fix

Pass the resolved path through `json.dumps` and strip the surrounding quotes before substituting. The result is valid JSON-string content (backslashes doubled, quotes escaped), so the substituted text remains parseable JSON, and `json.loads` decodes the doubled backslashes back into a single `\` in the final dict.

POSIX behavior is unchanged — for paths without characters that need escaping, `json.dumps(s)[1:-1] == s`.

## Test plan

- [x] Manual reproduction: confirmed pre-fix raises `JSONDecodeError` on Windows for claude / cursor / gemini / codex hook bundles
- [x] Manual verification: post-fix `_load_hook_bundles` returns valid dicts for all 4 agents on Windows; substituted command strings contain correct paths
- [ ] `pytest tests/test_cli_init.py` (existing `test_load_hook_bundles_claude_real_repo` and `test_apply_bundles_combines_post_and_pre` exercise this code path — they previously could only have failed on a Windows CI runner)
- [ ] Smoke test on POSIX to confirm no regression (expected: identical behavior, since `json.dumps(s)[1:-1] == s` for backslash-free strings)