### PR TITLE
fix: TOKEN_SAVIOR_MAX_FILES env var had no effect

### DIFF
--- a/src/token_savior/project_indexer.py
+++ b/src/token_savior/project_indexer.py
@@ -147,8 +147,8 @@ class ProjectIndexer:
         root_path: str,
         include_patterns: list[str] | None = None,
         exclude_patterns: list[str] | None = None,
-        max_file_size_bytes: int = 500_000,
-        max_files: int = 10_000,
+        max_file_size_bytes: int | None = None,
+        max_files: int | None = None,
     ):
         self.root_path = os.path.abspath(root_path)
         self.include_patterns = include_patterns or [

--- a/tests/test_project_indexer.py
+++ b/tests/test_project_indexer.py
@@ -244,6 +244,30 @@ class TestFileDiscovery:
 
         assert "big_file.py" not in idx.files
 
+    def test_max_files_env_var(self, tmp_path, monkeypatch):
+        # Create more files than the env-var limit
+        for i in range(5):
+            (tmp_path / f"file_{i}.py").write_text(f"x = {i}\n")
+
+        monkeypatch.setenv("TOKEN_SAVIOR_MAX_FILES", "3")
+        indexer = ProjectIndexer(str(tmp_path), include_patterns=["**/*.py"])
+        idx = indexer.index()
+
+        assert idx.total_files == 3
+
+    def test_max_file_size_env_var(self, tmp_path, monkeypatch):
+        large_file = tmp_path / "big_file.py"
+        large_file.write_text("x = 1\n" * 100_000)  # ~600KB
+        small_file = tmp_path / "small_file.py"
+        small_file.write_text("x = 1\n")
+
+        monkeypatch.setenv("TOKEN_SAVIOR_MAX_FILE_SIZE", "100")
+        indexer = ProjectIndexer(str(tmp_path), include_patterns=["**/*.py"])
+        idx = indexer.index()
+
+        assert "big_file.py" not in idx.files
+        assert "small_file.py" in idx.files
+
     def test_include_patterns_filter(self, sample_project):
         # Only include Python files
         indexer = ProjectIndexer(


### PR DESCRIPTION
## Summary

- `max_files` defaulted to `10_000` in `ProjectIndexer.__init__`, so `self.max_files = max_files or int(os.environ.get("TOKEN_SAVIOR_MAX_FILES", "10000"))` always short-circuited — env var was never read
- Same issue for `max_file_size_bytes` / `TOKEN_SAVIOR_MAX_FILE_SIZE`
- Fixed both by changing defaults to `None` so the `or` falls through when no explicit value is passed
- Added two tests covering both env vars