### PR TITLE
fix(edit): replace_symbol_source no longer deletes Java annotations

### DIFF
--- a/src/token_savior/edit_ops.py
+++ b/src/token_savior/edit_ops.py
@@ -72,23 +72,59 @@ def _debut_sans_decorateurs(
     la nouvelle source en apporte deja : dans ce cas l'appelant a decide
     lui-meme de ce qui surmonte la definition, on ne lui force rien.
 
-    Ecrit en defensif : toute lecture qui echoue rend `debut`, c'est-a-dire
-    l'ancien comportement. Un remplacement doit rater plutot que de deplacer
-    ses lignes au hasard.
+    On saute le prologue d'attributs plutot que de chercher une ligne de
+    definition. Chercher `def`/`class` liait la reponse a la syntaxe Python,
+    alors que la question ne l'est pas : le seul autre annotateur dont la
+    plage indexee englobe l'attribut est Java, ou aucune de ces trois amorces
+    n'apparait. Le scan tombait donc jusqu'au `return debut` final et
+    `@Override` etait ecrase. Constate le 27/07/2026 sur `toString`, plage
+    @L:2-5, annotation disparue du fichier sans que la relecture du symbole
+    remplace ne puisse le montrer -- ce qui manque est au-dessus de la
+    definition. TypeScript, C#, Rust et PHP ne sont pas concernes : leur plage
+    commence a la declaration, l'attribut n'en fait pas partie.
+
+    Un attribut peut porter ses arguments sur plusieurs lignes. On consomme
+    donc chaque attribut jusqu'a ce que ses parentheses et crochets se
+    referment, sinon on s'arreterait a l'interieur et on effacerait la fin de
+    ses arguments.
+
+    Ecrit en defensif : toute lecture qui echoue, et tout prologue dont le
+    solde ne se referme pas, rendent `debut`, c'est-a-dire l'ancien
+    comportement. Un remplacement doit rater plutot que de deplacer ses lignes
+    au hasard.
     """
-    if nouvelle_source.lstrip().startswith("@"):
+    if nouvelle_source.lstrip().startswith(_AMORCES_ATTRIBUT):
         return debut
     try:
         lignes, _ = _read_lines(chemin)
     except OSError:
         return debut
-    if debut - 1 >= len(lignes) or not lignes[debut - 1].lstrip().startswith("@"):
-        return debut
-    for numero in range(debut - 1, min(fin, len(lignes))):
-        depouillee = lignes[numero].lstrip()
-        if depouillee.startswith(("def ", "async def ", "class ")):
-            return numero + 1
-    return debut
+    borne = min(fin, len(lignes))
+    numero = debut - 1
+    while numero < borne and lignes[numero].lstrip().startswith(_AMORCES_ATTRIBUT):
+        solde = _solde_delimiteurs(lignes[numero])
+        numero += 1
+        while numero < borne and solde > 0:
+            solde += _solde_delimiteurs(lignes[numero])
+            numero += 1
+    return numero + 1 if numero < borne else debut
+
+
+# `@` couvre Python, Java et TypeScript ; `#[` couvre Rust et PHP 8. Les deux
+# derniers langages n'en ont pas besoin aujourd'hui -- leur plage commence a la
+# declaration -- mais l'amorce ne coute rien et la convention peut changer.
+_AMORCES_ATTRIBUT = ("@", "#[")
+
+
+def _solde_delimiteurs(ligne: str) -> int:
+    """Ouvrants moins fermants, pour suivre un attribut sur plusieurs lignes.
+
+    Compte sans comprendre les chaines : un attribut dont un litteral contient
+    une parenthese depareillee laisse le solde ouvert, la boucle appelante va
+    au bout de la plage et rend `debut`. C'est l'ancien comportement, donc une
+    annotation perdue dans ce cas precis, jamais un remplacement decale.
+    """
+    return sum(ligne.count(o) - ligne.count(f) for o, f in (("(", ")"), ("[", "]")))
 
 
 def edit_lines_in_symbol(

--- a/tests/test_replace_symbol_keeps_annotations.py
+++ b/tests/test_replace_symbol_keeps_annotations.py
@@ -1,0 +1,121 @@
+"""`replace_symbol_source` must not eat what sits above the definition.
+
+v4.20.0 stopped Python decorators from being deleted, but keyed the fix to
+Python definition heads:
+
+    if depouillee.startswith(("def ", "async def ", "class ")):
+
+The Java annotator puts `@Override` inside the symbol's line range, no head
+matches, and the scan falls through to the unchanged start -- so the
+replacement begins *at the annotation line* and overwrites it. Same failure
+the Python fix describes, in the one other language whose range convention
+includes the attribute: what disappears is above the definition, so re-reading
+the replaced symbol does not show it. An `@Override` or a `@Test` silently
+leaving a method is a semantic change that still compiles.
+"""
+from __future__ import annotations
+
+from token_savior.edit_ops import replace_symbol_source
+from token_savior.project_indexer import ProjectIndexer
+
+
+def _projet(tmp_path, nom: str, source: str):
+    (tmp_path / nom).write_text(source, encoding="utf-8")
+    return ProjectIndexer(str(tmp_path)).index()
+
+
+def test_java_annotation_survives_the_replacement(tmp_path) -> None:
+    index = _projet(tmp_path, "Api.java", (
+        "public class Api {\n"
+        "    @Override\n"
+        "    public String toString() {\n"
+        '        return "api";\n'
+        "    }\n"
+        "}\n"
+    ))
+    resultat = replace_symbol_source(index, "toString", (
+        "    public String toString() {\n"
+        '        return "API";\n'
+        "    }"
+    ))
+    assert not resultat.get("error"), resultat
+    source = (tmp_path / "Api.java").read_text(encoding="utf-8")
+    assert "@Override" in source, source
+    assert '"API"' in source, source
+
+
+def test_java_annotation_block_survives(tmp_path) -> None:
+    """Several annotations, one of them carrying arguments across lines."""
+    index = _projet(tmp_path, "Svc.java", (
+        "public class Svc {\n"
+        "    @Deprecated\n"
+        "    @SuppressWarnings({\n"
+        '        "unchecked",\n'
+        '        "rawtypes"\n'
+        "    })\n"
+        "    public int total() {\n"
+        "        return 1;\n"
+        "    }\n"
+        "}\n"
+    ))
+    resultat = replace_symbol_source(index, "total", (
+        "    public int total() {\n"
+        "        return 2;\n"
+        "    }"
+    ))
+    assert not resultat.get("error"), resultat
+    source = (tmp_path / "Svc.java").read_text(encoding="utf-8")
+    assert "@Deprecated" in source, source
+    assert "@SuppressWarnings" in source, source
+    assert '"rawtypes"' in source, source
+    assert "return 2;" in source, source
+
+
+def test_python_multiline_decorator_still_survives(tmp_path) -> None:
+    """The Python case the v4.20.0 fix covers, kept honest.
+
+    A decorator whose arguments span lines is where a naive "skip lines
+    starting with @" would stop one line too early and delete the rest.
+    """
+    index = _projet(tmp_path, "mod.py", (
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.parametrize(\n"
+        '    "x",\n'
+        "    [1, 2],\n"
+        ")\n"
+        "def cible(x):\n"
+        "    return x\n"
+    ))
+    resultat = replace_symbol_source(index, "cible", (
+        "def cible(x):\n"
+        "    return x * 2"
+    ))
+    assert not resultat.get("error"), resultat
+    source = (tmp_path / "mod.py").read_text(encoding="utf-8")
+    assert "@pytest.mark.parametrize(" in source, source
+    assert "[1, 2]," in source, source
+    assert "return x * 2" in source, source
+    compile(source, "mod.py", "exec")
+
+
+def test_caller_supplied_annotations_replace_the_existing_ones(tmp_path) -> None:
+    """New source bringing its own attribute decides for itself."""
+    index = _projet(tmp_path, "Old.java", (
+        "public class Old {\n"
+        "    @Deprecated\n"
+        "    public int n() {\n"
+        "        return 1;\n"
+        "    }\n"
+        "}\n"
+    ))
+    resultat = replace_symbol_source(index, "n", (
+        "    @Override\n"
+        "    public int n() {\n"
+        "        return 2;\n"
+        "    }"
+    ))
+    assert not resultat.get("error"), resultat
+    source = (tmp_path / "Old.java").read_text(encoding="utf-8")
+    assert "@Override" in source, source
+    assert "@Deprecated" not in source, source


### PR DESCRIPTION
`replace_symbol_source` deleted a Java method's annotations.

The v4.20.0 guard finds the definition line by scanning for a Python head:

```python
if depouillee.startswith(("def ", "async def ", "class ")):
    return numero + 1
```

Java is the one other language whose indexed range includes the attribute, and none of those three prefixes appear in it. The scan falls through to `return debut`, so the replacement starts at the annotation line and overwrites it.

```java
public class Api {
    @Override                       // range is @L:2-5 -- the annotation is in it
    public String toString() {
        return "api";
    }
}
```

After `replace_symbol_source("toString", ...)`:

```java
public class Api {
    public String toString() {      // @Override is gone
        return "API";
    }
}
```

Same failure mode the original Python fix describes: what disappears is *above* the definition, so re-reading the replaced symbol never shows it. An `@Override`, `@Test` or `@Transactional` leaving a method is a semantic change that still compiles.

### Approach

Skip the attribute prologue rather than hunt for a definition head — the question was never Python-specific, and keying it to Python syntax is what let Java through.

Attribute arguments can span lines (`@SuppressWarnings({...})`, `@pytest.mark.parametrize(...)`), so each attribute is consumed until its parentheses and brackets close. A prologue whose balance never closes — an unbalanced delimiter inside a string literal — falls back to the previous behaviour rather than moving the replacement to a guessed line. Losing an annotation in that corner is the old bug; a misplaced replacement would be a worse new one.

### Scope

Checked every annotator with an attribute syntax; only Java's range convention includes it, so only Java was affected:

| Language | Attribute | Range starts at | Was affected |
| --- | --- | --- | --- |
| Python | `@functools.cache` | decorator line | no — v4.20.0 covers it |
| Java | `@Override` | **annotation line** | **yes** |
| TypeScript | `@Injectable(...)` | `export class` line | no |
| C# | `[Obsolete(...)]` | declaration line | no |
| Rust | `#[inline]` | `pub fn` line | no |
| PHP | `#[Deprecated]` | declaration line | no |

The `#[` prefix is recognised anyway: it costs nothing and the convention can change.

### Tests

Four tests. The two Java ones were verified red on `main` — the second showed the whole multi-line annotation block deleted, not just one line. The two others were green before and after, and are there deliberately:

* the Python multi-line decorator is where a naive "skip lines starting with `@`" stops one line early and eats the arguments;
* caller-supplied attributes must still replace the existing ones, which is the one case where *not* moving the start is correct.

Suite: **2723 passed, 14 skipped**. `ruff==0.16.0` clean.

Closes #71
