### PR TITLE
fix(viewer): serve archived and superseded observations instead of 404

### DIFF
--- a/src/token_savior/memory/viewer.py
+++ b/src/token_savior/memory/viewer.py
@@ -529,6 +529,18 @@ def _build_handler() -> type:
             content = str(obs.get("content") or "")
             body = narrative or content
             meta_bits = [b for b in [obs_type, project, created] if b]
+            # Une observation retiree servie comme si elle etait courante
+            # serait pire que le 404 qu'elle rendait : c'est precisement
+            # l'echec que la peremption existe pour eviter. On la sert, et on
+            # dit qu'elle est retiree.
+            if obs.get("archived"):
+                remplacant = obs.get("superseded_by")
+                etat = (
+                    f"archived · superseded by #{int(remplacant)}"
+                    if remplacant
+                    else "archived"
+                )
+                meta_bits.insert(0, etat)
             return (
                 f'<div class="detail" id="d-{obs_id}">'
                 f'<div class="meta">{e(" · ".join(meta_bits))}</div>'
@@ -573,7 +585,13 @@ def _build_handler() -> type:
 
         def _handle_obs(self, obs_id: int, fmt: str = "") -> None:
             from token_savior import memory_db
-            rows = memory_db.observation_get([obs_id])
+            # `include_archived` : le defaut de `observation_get` est le bon
+            # pour un agent qui lit la memoire -- on ne lui sert pas un fait
+            # perime. Le visualiseur est l'inverse : c'est la surface d'audit,
+            # et une observation archivee ou remplacee y repondait 404. Le
+            # lien `superseded_by` existait donc dans les donnees et ne menait
+            # nulle part dans la seule interface capable de le suivre.
+            rows = memory_db.observation_get([obs_id], include_archived=True)
             if not rows:
                 if fmt == "html":
                     self._send_html(

--- a/tests/test_memory_viewer.py
+++ b/tests/test_memory_viewer.py
@@ -448,3 +448,79 @@ class TestStatusHtmlFragment:
         # A2-2 adds continuity to the JSON payload too.
         assert "continuity" in data
         assert "score" in data["continuity"]
+
+
+class TestArchivedObservations:
+    """The viewer is the audit surface, so it must show what memory retires.
+
+    v4.20.0 made `observation_get` exclude archived rows by default -- right
+    for an agent reading memory, which must not be served retired facts -- and
+    added `superseded_by` so an observation made false by a newer one is
+    *archived, never deleted*, explicitly so that "what was true in April" can
+    still be answered and a wrong supersession can be undone.
+
+    `_handle_obs` was not updated, so it answered 404 for exactly those rows:
+    the link exists in the data and dead-ends in the only UI that could follow
+    it, and undoing a supersession meant opening SQLite by hand.
+    """
+
+    def test_deleted_observation_is_still_served(self, _viewer_running):
+        port = _viewer_running
+        sid = memory_db.session_start(PROJECT)
+        oid = memory_db.observation_save(
+            sid, PROJECT, "convention", "retiree", "body content",
+        )
+        assert oid is not None
+        assert memory_db.observation_delete(oid) is True
+
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/obs/{oid}") as r:
+            data = json.loads(r.read())
+        assert data["id"] == oid
+        assert data["title"] == "retiree"
+        assert data["archived"] == 1
+
+    def test_superseded_observation_is_still_served(self, _viewer_running):
+        port = _viewer_running
+        sid = memory_db.session_start(PROJECT)
+        ancienne = memory_db.observation_save(
+            sid, PROJECT, "insight", "ancienne", "body content",
+        )
+        nouvelle = memory_db.observation_save(
+            sid, PROJECT, "insight", "nouvelle", "other body",
+        )
+        assert ancienne is not None and nouvelle is not None
+        conn = memory_db.get_db()
+        try:
+            conn.execute(
+                "UPDATE observations SET archived=1, superseded_by=? WHERE id=?",
+                (nouvelle, ancienne),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/obs/{ancienne}") as r:
+            data = json.loads(r.read())
+        assert data["id"] == ancienne
+        assert data["superseded_by"] == nouvelle, data
+
+    def test_html_detail_marks_the_row_as_retired(self, _viewer_running):
+        """A retired row served as if current would be worse than a 404."""
+        port = _viewer_running
+        sid = memory_db.session_start(PROJECT)
+        oid = memory_db.observation_save(
+            sid, PROJECT, "convention", "retiree-html", "body content",
+        )
+        assert oid is not None
+        assert memory_db.observation_delete(oid) is True
+
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/obs/{oid}?fmt=html") as r:
+            page = r.read().decode("utf-8")
+        assert "retiree-html" in page
+        assert "archived" in page.lower(), page[:400]
+
+    def test_absent_observation_is_still_a_404(self, _viewer_running):
+        port = _viewer_running
+        with pytest.raises(Exception) as exc_info:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/obs/999999")
+        assert "404" in str(exc_info.value)


### PR DESCRIPTION
v4.20.0 made `observation_get` exclude archived rows by default and added `superseded_by`, so an observation made false by a newer one is *archived, never deleted* — explicitly so that "what was true in April" can still be answered and a wrong supersession can be undone.

`_handle_obs` was not updated:

```python
rows = memory_db.observation_get([obs_id])   # filters AND archived = 0
if not rows:
    ... 404 ...
```

So the viewer answers **404 for exactly the rows the feature was built to preserve**. The `superseded_by` link exists in the data and dead-ends in the only interface that could follow it; undoing a wrong supersession means opening SQLite by hand.

### Fix

`include_archived=True` at that one call site. The default on `observation_get` itself stays as it is — an agent reading memory must not be served retired facts. The viewer is the audit surface and wants the opposite default; that is the whole distinction.

The detail view now marks the row and names its replacement (`archived · superseded by #12`). Serving a retired observation as if it were current would be worse than the 404 it replaces, since that is precisely the failure supersession exists to prevent.

### Tests

Four tests in `TestArchivedObservations`, reusing the existing `_viewer_running` fixture. Three verified red on `main` with `HTTPError: HTTP Error 404`:

* a deleted observation is still served, and reports `archived == 1`;
* a superseded one is served and still carries `superseded_by`;
* the HTML detail marks it as retired rather than rendering it as current.

The fourth asserts an observation that genuinely does not exist is still a 404, so the fix cannot be "return everything".

Suite: **2723 passed, 14 skipped**. `ruff==0.16.0` clean.

Closes #72
