### PR TITLE
fix(guard): stop refusing edits in vendored trees, prune session state

### DIFF
--- a/hooks/ts_discipline_guard.py
+++ b/hooks/ts_discipline_guard.py
@@ -48,6 +48,7 @@ import json
 import os
 import re
 import sys
+import time
 from pathlib import Path
 
 # Extensions Token Savior can edit structurally. Everything else (.md, .json,
@@ -144,10 +145,39 @@ def seen_symbols(session_id: str) -> set[str]:
         return set()
 
 
+STATE_TTL_S = 7 * 86400
+
+
+def prune_state(dossier: Path) -> None:
+    """Drop session files nothing will read again.
+
+    One file per session accumulated forever, in a directory the user never
+    sees and no command names. Pruning on write keeps it to a handful of lines
+    and needs no new command: the directory stays small precisely because it
+    is pruned, so the scan it costs stays cheap.
+
+    Best-effort throughout — a state directory we cannot tidy must never be
+    the reason a tool call is refused.
+    """
+    limite = time.time() - STATE_TTL_S
+    try:
+        entrees = list(dossier.iterdir())
+    except OSError:
+        return
+    for entree in entrees:
+        try:
+            if entree.suffix == ".json" and entree.stat().st_mtime < limite:
+                entree.unlink()
+        except OSError:
+            pass
+
+
 def record_symbols(session_id: str, names: list[str]) -> None:
     seen = seen_symbols(session_id) | {n for n in names if n}
     try:
-        state_file(session_id).write_text(json.dumps(sorted(seen)), encoding="utf-8")
+        chemin = state_file(session_id)
+        prune_state(chemin.parent)
+        chemin.write_text(json.dumps(sorted(seen)), encoding="utf-8")
     except OSError:
         pass
 
@@ -182,11 +212,21 @@ def verdict_edit_without_context(tool: str, tool_input: dict, session_id: str) -
 
 
 def verdict_native_edit(tool_input: dict) -> str | None:
+    """Native `Edit`/`Write` on indexed source.
+
+    Goes through `is_indexed_code` like every other verdict. It used to repeat
+    the checks inline and drop `TOLERATED_PATHS` on the way, so the same file
+    was readable and not editable: `Read` on `node_modules/pkg/mod.py` passed,
+    `Edit` on it was refused. The remedy the message proposes cannot work
+    there — those trees are excluded from the index, so there is no symbol to
+    replace, and the only way out was `TS_GUARD_OFF=1`.
+
+    `is_indexed_code` also requires the file to exist, which keeps the
+    "creating a file has no symbol to replace" exit.
+    """
     path = str(tool_input.get("file_path") or "")
-    if not path.endswith(CODE_EXTENSIONS):
+    if not is_indexed_code(path):
         return None
-    if not os.path.exists(path):
-        return None  # creating a file: no symbol to replace
     root = indexed_root(path)
     if not root:
         return None

--- a/tests/test_ts_discipline_guard.py
+++ b/tests/test_ts_discipline_guard.py
@@ -12,6 +12,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -332,3 +333,75 @@ def test_fail_open_sur_entree_malformee(brut: str, tmp_path: Path) -> None:
                        check=False)
     assert r.returncode == 0
     assert not r.stdout.strip()
+
+
+# --- Editions dans les arbres vendorises ---------------------------------- #
+
+@pytest.mark.parametrize("outil", ["Edit", "Write", "NotebookEdit"])
+@pytest.mark.parametrize("dossier", ["node_modules", ".venv", "dist", "build", "__pycache__"])
+def test_laisse_editer_les_dependances_vendorisees(
+    projet: Path, tmp_path: Path, outil: str, dossier: str,
+) -> None:
+    """Le meme chemin ne peut pas etre lisible et non editable.
+
+    `verdict_native_read` passe par `is_indexed_code`, qui honore
+    TOLERATED_PATHS ; `verdict_native_edit` refaisait le controle sur place et
+    l'oubliait. Read passait, Edit etait refuse, sur le meme fichier.
+
+    Le remede propose -- `get_edit_context` puis `replace_symbol_source` -- ne
+    peut pas fonctionner ici : ces arbres sont exclus de l'index, il n'y a
+    aucun symbole a remplacer. La seule issue etait TS_GUARD_OFF=1, ce qui est
+    exactement le faux positif que ce fichier dit vouloir eviter.
+    """
+    f = projet / dossier / "paquet" / "mod.py"
+    f.parent.mkdir(parents=True)
+    f.write_text("x = 1\n", encoding="utf-8")
+    payload = {
+        "session_id": "s1",
+        "tool_name": outil,
+        "tool_input": {"file_path": str(f)},
+    }
+    assert lancer(payload, tmp_path / "etat") is None
+
+
+@pytest.mark.parametrize("outil", ["Edit", "Write"])
+def test_refuse_toujours_l_edition_du_vrai_code_du_projet(
+    projet: Path, tmp_path: Path, outil: str,
+) -> None:
+    """Le controle ajoute ne doit rien laisser passer d'autre."""
+    f = projet / "app" / "calc.py"
+    f.parent.mkdir(parents=True)
+    f.write_text("def x():\n    return 1\n", encoding="utf-8")
+    payload = {
+        "session_id": "s1",
+        "tool_name": outil,
+        "tool_input": {"file_path": str(f)},
+    }
+    assert "native edit" in raison(lancer(payload, tmp_path / "etat"))
+
+
+# --- Etat de session ------------------------------------------------------ #
+
+def test_les_etats_de_session_perimes_sont_effaces(tmp_path: Path) -> None:
+    """Un fichier par session, pour toujours, dans XDG_STATE_HOME.
+
+    Rien ne les supprimait et aucune commande ne les nomme. Sur des mois
+    d'usage quotidien cela fait des milliers de fichiers dans un repertoire
+    que l'utilisateur ne voit jamais, et une fuite lente de ce sur quoi il a
+    travaille.
+    """
+    etat = tmp_path / "etat"
+    dossier = etat / "token-savior" / "discipline-guard"
+    dossier.mkdir(parents=True)
+    vieux = dossier / "session-oubliee.json"
+    vieux.write_text('["symbole"]', encoding="utf-8")
+    vieil_age = time.time() - 30 * 86400
+    os.utime(vieux, (vieil_age, vieil_age))
+    recent = dossier / "session-recente.json"
+    recent.write_text('["symbole"]', encoding="utf-8")
+
+    lancer(contexte("cible"), etat)
+
+    assert not vieux.exists(), "l'etat perime est reste"
+    assert recent.exists(), "un etat recent a ete emporte"
+    assert (dossier / "s1.json").exists(), "l'etat de la session courante manque"


### PR DESCRIPTION
Two guard fixes, both in the "not refusing too much is the hard part" category the module docstring is built around.

### Edits in vendored trees — `#73`

`verdict_native_read` goes through `is_indexed_code`, which honours `TOLERATED_PATHS`. `verdict_native_edit` repeated the checks inline and dropped that one:

```
Edit .../proj/node_modules/pkg/mod.py -> deny
Read .../proj/node_modules/pkg/mod.py -> allowed     # same file
```

The remedy the denial proposes cannot work there. Those trees are excluded from the index, so there is no symbol for `get_edit_context` to return and nothing for `replace_symbol_source` to replace — the only way out is `TS_GUARD_OFF=1`. A patched dependency, a generated client, a `.venv` shim opened while debugging all hit it, and each one is a nudge toward switching the guard off for good.

Fixed by routing the verdict through the same predicate as the others. `is_indexed_code` also requires the file to exist, so the "creating a file has no symbol to replace" exit is preserved rather than reimplemented.

### Session state pruning — `#77`

One JSON file per session, in `~/.local/state/token-savior/discipline-guard/`, forever. Nothing removed them and no command names them. Now pruned on write with a seven-day TTL: the directory stays small precisely because it is pruned, so the scan it costs stays cheap, and it needs no new command. Best-effort throughout — a state directory that cannot be tidied must never be the reason a tool call is refused.

### Tests

16 verified red on `main`:

* `test_laisse_editer_les_dependances_vendorisees` — 3 tools × 5 tolerated directories, all denied before, all allowed after;
* `test_les_etats_de_session_perimes_sont_effaces` — a 30-day-old state file survives; it also asserts a recent file and the current session's file are *kept*, so the fix cannot be "delete everything".

`test_refuse_toujours_l_edition_du_vrai_code_du_projet` was green before and after, and is there so widening the exemption cannot quietly disable rule 2.

Suite: **2737 passed, 14 skipped**. `ruff==0.16.0` clean over the CI scope (`src/ tests/`).

Closes #73
Closes #77
