### PR TITLE
fix(memory): resolve TOKEN_SAVIOR_DATA_DIR when the DB is opened, not at import

### DIFF
--- a/src/token_savior/db_core.py
+++ b/src/token_savior/db_core.py
@@ -38,7 +38,30 @@ def _resoudre_repertoire_donnees() -> Path:
     return base / "token-savior"
 
 
-MEMORY_DB_PATH = _resoudre_repertoire_donnees() / "memory.db"
+# Point de surcharge : la suite de tests le rebinde pour toute la session, et
+# 31 modules de test le rebindent au cas par cas. C'est le mecanisme documente
+# en tete de `memory_db`, il doit continuer de gagner.
+_CHEMIN_INITIAL = _resoudre_repertoire_donnees() / "memory.db"
+MEMORY_DB_PATH = _CHEMIN_INITIAL
+
+
+def chemin_memoire() -> Path:
+    """Ou vit la base memoire, demande au moment ou on l'ouvre.
+
+    `TOKEN_SAVIOR_DATA_DIR` et `XDG_DATA_HOME` etaient lus une fois, a
+    l'import. Ils ne comptaient donc que s'ils etaient deja poses avant le
+    premier `import token_savior.db_core` : un script d'enrobage qui configure
+    l'environnement apres avoir importe le paquet, un hote qui le fait par
+    projet, etaient ignores en silence et la memoire partait dans
+    `~/.local/share/token-savior`. Meme forme que le defaut corrige en 4.20.0 :
+    la valeur est lisible, et pas lue au moment ou elle compte.
+
+    Une surcharge explicite l'emporte ; a defaut on redemande a
+    l'environnement plutot que de rejouer une reponse datee de l'import.
+    """
+    if MEMORY_DB_PATH != _CHEMIN_INITIAL:
+        return Path(MEMORY_DB_PATH)
+    return _resoudre_repertoire_donnees() / "memory.db"
 
 _SCHEMA_PATH = Path(__file__).parent / "memory_schema.sql"
 
@@ -104,7 +127,7 @@ def run_migrations(db_path: Path | str | None = None) -> None:
     free of schema inspection; also invoked lazily from get_db() as a
     safety net (e.g. for tests that patch MEMORY_DB_PATH).
     """
-    path = Path(db_path) if db_path else MEMORY_DB_PATH
+    path = Path(db_path) if db_path else chemin_memoire()
     path_str = str(path)
     if path_str in _migrated_paths:
         return
@@ -332,7 +355,7 @@ def get_db(db_path: Path | None = None) -> sqlite3.Connection:
     connection so that the obs_vectors vec0 table is queryable. Missing
     extension is silent (warning emitted once, see _maybe_load_sqlite_vec).
     """
-    path = db_path or MEMORY_DB_PATH
+    path = db_path or chemin_memoire()
     run_migrations(path)
     conn = sqlite3.connect(str(path))
     conn.row_factory = sqlite3.Row

--- a/src/token_savior/memory_db.py
+++ b/src/token_savior/memory_db.py
@@ -33,16 +33,28 @@ from .db_core import (  # noqa: F401
 )
 
 
+def _surcharge() -> Path | None:
+    """Le chemin impose ici, ou None pour laisser `db_core` resoudre.
+
+    Ce module garde une copie de `MEMORY_DB_PATH` prise a l'import, et la
+    passait toujours explicitement : `db_core` recevait donc une valeur figee
+    et ne pouvait jamais consulter l'environnement. Tant que personne n'a
+    rebinde cette copie, on ne passe rien et la resolution revient a
+    `db_core.chemin_memoire()`.
+    """
+    return None if MEMORY_DB_PATH == db_core._CHEMIN_INITIAL else Path(MEMORY_DB_PATH)
+
+
 def get_db(db_path: Path | str | None = None) -> sqlite3.Connection:
-    return db_core.get_db(db_path or MEMORY_DB_PATH)
+    return db_core.get_db(db_path or _surcharge())
 
 
 def db_session(db_path: Path | str | None = None) -> AbstractContextManager[sqlite3.Connection]:
-    return db_core.db_session(db_path or MEMORY_DB_PATH)
+    return db_core.db_session(db_path or _surcharge())
 
 
 def run_migrations(db_path: Path | str | None = None) -> None:
-    return db_core.run_migrations(db_path or MEMORY_DB_PATH)
+    return db_core.run_migrations(db_path or _surcharge())
 
 
 # ---- memory/ subpackage re-exports (public surface) ----------------------

--- a/tests/test_data_dir_resolution.py
+++ b/tests/test_data_dir_resolution.py
@@ -1,0 +1,84 @@
+"""`TOKEN_SAVIOR_DATA_DIR` must be read when the database is opened.
+
+v4.20.0 made the memory database honour `TOKEN_SAVIOR_DATA_DIR` and
+`XDG_DATA_HOME`, which it previously ignored -- but froze the answer at import:
+
+    MEMORY_DB_PATH = _resoudre_repertoire_donnees() / "memory.db"
+
+So the variables only count if they are already set when
+`token_savior.db_core` is first imported. Anything setting them afterwards --
+a wrapper script that configures the environment after importing the package,
+an embedding host doing it per project -- is silently ignored and the engine
+writes to `~/.local/share/token-savior` instead. Same shape as the defect that
+change fixed: the value is readable, and not read at the moment it matters.
+
+Run in a clean interpreter rather than by touching module state: the suite
+rebinds `MEMORY_DB_PATH` session-wide for isolation, and that rebinding is an
+override which must keep winning. What is under test is the case where nobody
+overrode anything, which only a fresh process has.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def _dans_un_interprete_neuf(programme: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("TOKEN_SAVIOR_DATA_DIR", None)
+    env.pop("XDG_DATA_HOME", None)
+    return subprocess.run(
+        [sys.executable, "-c", programme],
+        capture_output=True, text=True, env=env, timeout=120, check=False,
+    )
+
+
+def test_data_dir_set_after_import_is_honoured(tmp_path) -> None:
+    cible = tmp_path / "ailleurs"
+    programme = (
+        "import os\n"
+        "from token_savior import memory_db\n"
+        f"os.environ['TOKEN_SAVIOR_DATA_DIR'] = {str(cible)!r}\n"
+        "memory_db.get_db().close()\n"
+    )
+    resultat = _dans_un_interprete_neuf(programme)
+    assert resultat.returncode == 0, resultat.stderr
+    assert (cible / "memory.db").exists(), resultat.stderr
+
+
+def test_xdg_data_home_set_after_import_is_honoured(tmp_path) -> None:
+    cible = tmp_path / "xdg"
+    programme = (
+        "import os\n"
+        "from token_savior import memory_db\n"
+        f"os.environ['XDG_DATA_HOME'] = {str(cible)!r}\n"
+        "memory_db.get_db().close()\n"
+    )
+    resultat = _dans_un_interprete_neuf(programme)
+    assert resultat.returncode == 0, resultat.stderr
+    assert (cible / "token-savior" / "memory.db").exists(), resultat.stderr
+
+
+def test_an_explicit_rebinding_still_wins(tmp_path) -> None:
+    """The override the whole test suite depends on must keep winning.
+
+    `conftest` rebinds `MEMORY_DB_PATH` for the session, and 31 test modules
+    rebind it per case. Resolving the environment at use time must not quietly
+    take that away, or the suite goes back to writing into the user's real
+    database.
+    """
+    impose = tmp_path / "impose.db"
+    ignore = tmp_path / "ignore"
+    programme = (
+        "import os\n"
+        "from token_savior import db_core, memory_db\n"
+        f"os.environ['TOKEN_SAVIOR_DATA_DIR'] = {str(ignore)!r}\n"
+        f"db_core.MEMORY_DB_PATH = {str(impose)!r}\n"
+        f"memory_db.MEMORY_DB_PATH = {str(impose)!r}\n"
+        "memory_db.get_db().close()\n"
+    )
+    resultat = _dans_un_interprete_neuf(programme)
+    assert resultat.returncode == 0, resultat.stderr
+    assert impose.exists(), resultat.stderr
+    assert not (ignore / "memory.db").exists(), "the environment overrode an override"

--- a/tests/test_memory_public_surface.py
+++ b/tests/test_memory_public_surface.py
@@ -69,6 +69,7 @@ EXPECTED_PUBLIC = [
     "_read_activity_tracker",
     "_read_session_override",
     "_recalculate_relevance_scores",
+    "_surcharge",
     "_write_activity_tracker",
     "analyze_prompt_patterns",
     "annotations",


### PR DESCRIPTION
`MEMORY_DB_PATH` was computed once, at import:

```python
MEMORY_DB_PATH = _resoudre_repertoire_donnees() / "memory.db"
```

so `TOKEN_SAVIOR_DATA_DIR` and `XDG_DATA_HOME` only counted when they were already set before `token_savior.db_core` was first imported. Anything setting them afterwards — a wrapper script that configures the environment after importing the package, a host doing it per project — was silently ignored and the engine wrote to `~/.local/share/token-savior`.

Same shape as the defect v4.20.0 fixed: the variable is *readable*, and not *read* at the moment it matters.

### Keeping the override intact

`MEMORY_DB_PATH` is not just a default, it is the documented override point — `conftest` rebinds it for the whole session (after finding 284 test observations in a real user database) and 31 test modules rebind it per case. So the rule is: **an explicit rebinding wins; absent one, ask the environment** rather than replay an answer dated from import.

`memory_db` needed the same treatment. It keeps its own import-time copy and passed it to `db_core` on every call, so `db_core` never got the chance to resolve anything even once it could. It now passes nothing unless that copy was actually rebound.

### Tests

Three, run in a clean interpreter rather than by touching module state — the suite's own session-wide rebinding is an override, so the no-override case only exists in a fresh process. Two verified red on `main`:

* `TOKEN_SAVIOR_DATA_DIR` set after the import is honoured;
* `XDG_DATA_HOME` set after the import is honoured.

The third was green before and after and is the one that matters for regressions: an explicit rebinding still wins over the environment. Without it, this change would quietly take away the isolation the suite depends on and send tests back into the user's real database.

One line added to the `memory_db` public-surface snapshot for the new private helper, as that test asks.

Suite: **2722 passed, 14 skipped**. `ruff==0.16.0` clean.

Note: touches `db_core.py`, as does #80. The regions are different (constant + two default-resolution lines vs. the migration body), but #80 is the more urgent of the two if you want an order.

Closes #75
