### PR TITLE
fix(memory): make every memory submodule importable on its own

### DIFF
--- a/src/token_savior/memory/_facade.py
+++ b/src/token_savior/memory/_facade.py
@@ -1,0 +1,46 @@
+"""Lazy handle on the `memory_db` facade, to break an import cycle.
+
+Nineteen modules of this subpackage opened their connections through
+`from token_savior import memory_db`, and `memory_db` re-exports their names
+back with `from token_savior.memory.X import (...)`. That cycle resolved in
+one direction only:
+
+* facade first -- `memory_db` runs, reaches its import of X, X runs to
+  completion, the facade collects its names;
+* submodule first -- X stops at its import line to run `memory_db`, which
+  immediately asks X for names it has not defined yet, and raises
+  ``ImportError: cannot import name ... from partially initialized module``.
+
+So `python -c "import token_savior.memory.observations"` failed while
+`import token_savior.memory_db` first made it work. Invisible through the MCP
+server, which always goes through the facade; it bit a test module, a script,
+`python -m`, a debugger session, and read as a broken install rather than an
+import-order constraint.
+
+The cycle is cut here rather than in nineteen call sites. Importing this
+module pulls nothing: the facade is resolved on first attribute access, by
+which time both modules exist. Resolving per access also keeps the override
+working -- rebinding `memory_db.MEMORY_DB_PATH`, which the test suite does
+session-wide and thirty-one test modules do per case, still reaches every
+submodule, because nothing here holds a copy of anything.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class _FacadeMemoire:
+    """Forwards attribute access to `token_savior.memory_db`, on demand."""
+
+    __slots__ = ()
+
+    def __getattr__(self, nom: str) -> Any:
+        from token_savior import memory_db as _reel
+
+        return getattr(_reel, nom)
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return "<token_savior.memory_db (lazy)>"
+
+
+memory_db = _FacadeMemoire()

--- a/src/token_savior/memory/auto_extract.py
+++ b/src/token_savior/memory/auto_extract.py
@@ -184,7 +184,7 @@ def _save_extracted(items: list[dict], project_root: str) -> int:
     if not items or not project_root:
         return 0
     try:
-        from token_savior import memory_db
+        from token_savior.memory._facade import memory_db
     except Exception:
         return 0
     saved = 0
@@ -213,7 +213,7 @@ def _save_extracted(items: list[dict], project_root: str) -> int:
 def _resolve_project_root() -> str:
     """Fallback project resolution: pick the most-observed project_root."""
     try:
-        from token_savior import memory_db
+        from token_savior.memory._facade import memory_db
         db = memory_db.get_db()
         row = db.execute(
             "SELECT project_root FROM observations "

--- a/src/token_savior/memory/budget.py
+++ b/src/token_savior/memory/budget.py
@@ -9,7 +9,7 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
+from token_savior.memory._facade import memory_db
 
 # Claude Max effective context window. Treat as a soft ceiling for budgeting;
 # we measure observable consumption only (tokens we injected via hooks).

--- a/src/token_savior/memory/bus.py
+++ b/src/token_savior/memory/bus.py
@@ -13,8 +13,8 @@ import sys
 import time
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import relative_age
+from token_savior.memory._facade import memory_db
 
 DEFAULT_VOLATILE_TTL_DAYS = 1
 

--- a/src/token_savior/memory/consistency.py
+++ b/src/token_savior/memory/consistency.py
@@ -11,8 +11,8 @@ import sys
 import time
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import relative_age
+from token_savior.memory._facade import memory_db
 
 #: Validity below this threshold quarantines the observation.
 CONSISTENCY_QUARANTINE_THRESHOLD = 0.40

--- a/src/token_savior/memory/corpora.py
+++ b/src/token_savior/memory/corpora.py
@@ -10,8 +10,8 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import _json_dumps, _now_epoch, _now_iso
+from token_savior.memory._facade import memory_db
 
 
 def corpus_build(

--- a/src/token_savior/memory/decay.py
+++ b/src/token_savior/memory/decay.py
@@ -10,8 +10,8 @@ import sys
 import time
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import _now_epoch, _now_iso
+from token_savior.memory._facade import memory_db
 
 _DECAY_IMMUNE_TYPES = frozenset({"guardrail", "convention", "decision", "user", "feedback"})
 

--- a/src/token_savior/memory/dedup.py
+++ b/src/token_savior/memory/dedup.py
@@ -9,7 +9,7 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
+from token_savior.memory._facade import memory_db
 from token_savior.memory._text_utils import _jaccard
 
 

--- a/src/token_savior/memory/distillation.py
+++ b/src/token_savior/memory/distillation.py
@@ -10,8 +10,8 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import _json_dumps, _now_epoch, _now_iso, content_hash
+from token_savior.memory._facade import memory_db
 
 
 def run_mdl_distillation(

--- a/src/token_savior/memory/embeddings.py
+++ b/src/token_savior/memory/embeddings.py
@@ -202,8 +202,8 @@ def backfill_obs_vectors(
       * pending  : total - (previously_indexed + indexed_this_run)
       * reason   : filled when status != "ok"
     """
-    from token_savior import memory_db
     from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
+    from token_savior.memory._facade import memory_db
 
     if not VECTOR_SEARCH_AVAILABLE:
         return {
@@ -269,8 +269,8 @@ def backfill_obs_vectors(
 
 def vector_coverage(project_root: str) -> dict[str, Any]:
     """Return {total, indexed, percent, available} for a project."""
-    from token_savior import memory_db
     from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
+    from token_savior.memory._facade import memory_db
 
     result: dict[str, Any] = {
         "total": 0, "indexed": 0, "percent": 0.0,

--- a/src/token_savior/memory/events.py
+++ b/src/token_savior/memory/events.py
@@ -9,8 +9,8 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import _json_dumps, _now_epoch, _now_iso
+from token_savior.memory._facade import memory_db
 
 
 def event_save(

--- a/src/token_savior/memory/health.py
+++ b/src/token_savior/memory/health.py
@@ -10,7 +10,7 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
+from token_savior.memory._facade import memory_db
 from token_savior.memory._text_utils import _jaccard
 
 

--- a/src/token_savior/memory/index.py
+++ b/src/token_savior/memory/index.py
@@ -11,8 +11,8 @@ import sys
 import time
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import relative_age
+from token_savior.memory._facade import memory_db
 
 _TYPE_SCORES = {
     "guardrail": 1.0, "ruled_out": 0.95, "convention": 0.9, "warning": 0.8,

--- a/src/token_savior/memory/lattice.py
+++ b/src/token_savior/memory/lattice.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import sqlite3
 import sys
 
-from token_savior import memory_db
 from token_savior.db_core import _now_epoch, relative_age
+from token_savior.memory._facade import memory_db
 
 # Granularity levels for source-fetching tools:
 #   0 = full source (no compression)

--- a/src/token_savior/memory/ledger.py
+++ b/src/token_savior/memory/ledger.py
@@ -190,7 +190,7 @@ def classify_miss(
         # Resolve via the fully-formed memory_db module (its observation_search
         # attribute) rather than importing observations directly, which would
         # trip the observations<->memory_db import cycle.
-        from token_savior import memory_db
+        from token_savior.memory._facade import memory_db
         search_fn = memory_db.observation_search
 
     query = " OR ".join(f'"{t}"' for t in tokens)

--- a/src/token_savior/memory/links.py
+++ b/src/token_savior/memory/links.py
@@ -11,8 +11,8 @@ import sys
 import time
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import _now_iso
+from token_savior.memory._facade import memory_db
 
 _PROMOTION_TYPE_RANK = {
     "note": 1, "bugfix": 2, "decision": 2,

--- a/src/token_savior/memory/observations.py
+++ b/src/token_savior/memory/observations.py
@@ -10,7 +10,6 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import (
     _json_dumps,
     _now_epoch,
@@ -19,6 +18,7 @@ from token_savior.db_core import (
     relative_age,
     strip_private,
 )
+from token_savior.memory._facade import memory_db
 from token_savior.memory.bus import DEFAULT_VOLATILE_TTL_DAYS
 from token_savior.memory.consistency import check_symbol_staleness
 from token_savior.memory.decay import (

--- a/src/token_savior/memory/prompts.py
+++ b/src/token_savior/memory/prompts.py
@@ -9,8 +9,8 @@ import sqlite3
 import sys
 import time
 
-from token_savior import memory_db
 from token_savior.db_core import _now_epoch, _now_iso, strip_private
+from token_savior.memory._facade import memory_db
 from token_savior.memory._text_utils import _STOPWORDS, _TOKEN_RE
 
 

--- a/src/token_savior/memory/reasoning.py
+++ b/src/token_savior/memory/reasoning.py
@@ -10,7 +10,6 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import (
     _fts5_safe_query,
     _json_dumps,
@@ -19,6 +18,7 @@ from token_savior.db_core import (
     observation_hash,
     relative_age,
 )
+from token_savior.memory._facade import memory_db
 from token_savior.memory._text_utils import _jaccard
 
 

--- a/src/token_savior/memory/roi.py
+++ b/src/token_savior/memory/roi.py
@@ -13,7 +13,7 @@ import sys
 import time
 from typing import Any
 
-from token_savior import memory_db
+from token_savior.memory._facade import memory_db
 
 _ROI_LAMBDA = 0.05  # exponential decay per day since last access
 _ROI_HORIZON_DAYS = 30

--- a/src/token_savior/memory/sessions.py
+++ b/src/token_savior/memory/sessions.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import sqlite3
 import sys
 
-from token_savior import memory_db
 from token_savior.db_core import _json_dumps, _now_epoch, _now_iso
+from token_savior.memory._facade import memory_db
 
 
 def session_start(project_root: str) -> int:

--- a/src/token_savior/memory/stats.py
+++ b/src/token_savior/memory/stats.py
@@ -9,7 +9,7 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
+from token_savior.memory._facade import memory_db
 
 
 def get_stats(project_root: str | None = None) -> dict[str, Any]:

--- a/src/token_savior/memory/summaries.py
+++ b/src/token_savior/memory/summaries.py
@@ -9,8 +9,8 @@ import sqlite3
 import sys
 from typing import Any
 
-from token_savior import memory_db
 from token_savior.db_core import _json_dumps, _now_epoch, _now_iso
+from token_savior.memory._facade import memory_db
 
 
 def summary_save(

--- a/src/token_savior/memory/symbol_embeddings.py
+++ b/src/token_savior/memory/symbol_embeddings.py
@@ -206,8 +206,8 @@ def reindex_project_symbols(
       * elapsed_s  : wall clock
       * reason     : filled when status != "ok"
     """
-    from token_savior import memory_db
     from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
+    from token_savior.memory._facade import memory_db
     from token_savior.memory.embeddings import is_available
 
     if not VECTOR_SEARCH_AVAILABLE:
@@ -352,8 +352,8 @@ def search_symbols_semantic(
     contract still holds via the read-only schema + ``find_symbol``
     verification gate before any destructive operation on a hit.
     """
-    from token_savior import memory_db
     from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
+    from token_savior.memory._facade import memory_db
     from token_savior.memory.embeddings import embed
 
     if not VECTOR_SEARCH_AVAILABLE:

--- a/src/token_savior/memory/turn_capture.py
+++ b/src/token_savior/memory/turn_capture.py
@@ -218,7 +218,7 @@ def capture_turn(transcript_path: str, project_root: str) -> list[dict]:
     if not raw:
         return []
 
-    from token_savior import memory_db
+    from token_savior.memory._facade import memory_db
 
     saved = []
     for item in _parse_items(raw):

--- a/src/token_savior/memory/viewer.py
+++ b/src/token_savior/memory/viewer.py
@@ -249,7 +249,7 @@ def _active_project_root() -> str:
     except Exception:
         pass
     try:
-        from token_savior import memory_db
+        from token_savior.memory._facade import memory_db
         with memory_db.db_session() as conn:
             row = conn.execute(
                 "SELECT project_root FROM observations "
@@ -572,7 +572,7 @@ def _build_handler() -> type:
         # ── route handlers ────────────────────────────────────────────────
 
         def _handle_obs(self, obs_id: int, fmt: str = "") -> None:
-            from token_savior import memory_db
+            from token_savior.memory._facade import memory_db
             rows = memory_db.observation_get([obs_id])
             if not rows:
                 if fmt == "html":
@@ -591,7 +591,7 @@ def _build_handler() -> type:
                 self._send_json(200, obs)
 
         def _handle_search(self, q: str, limit: int, fmt: str = "") -> None:
-            from token_savior import memory_db
+            from token_savior.memory._facade import memory_db
             project = _active_project_root()
             if q:
                 rows = memory_db.observation_search(
@@ -613,7 +613,7 @@ def _build_handler() -> type:
                 })
 
         def _handle_status(self, fmt: str = "") -> None:
-            from token_savior import memory_db
+            from token_savior.memory._facade import memory_db
             project = _active_project_root()
             db = memory_db.get_db()
             try:

--- a/tests/test_memory_submodules_import_standalone.py
+++ b/tests/test_memory_submodules_import_standalone.py
@@ -1,0 +1,92 @@
+"""Every `token_savior.memory.*` module must import on its own.
+
+    $ python -c "import token_savior.memory.observations"
+    ImportError: cannot import name '_CORRUPTION_MARKERS' from partially
+    initialized module 'token_savior.memory.observations'
+    (most likely due to a circular import)
+
+The cycle is `memory.X` -> `memory_db` -> `memory.X`, and it resolves in one
+direction only. Facade first: `memory_db` runs, reaches its
+`from token_savior.memory.X import (...)`, X runs to completion -- its own
+`from token_savior import memory_db` binds the partially initialised *module
+object*, which is fine since it is only dereferenced at call time -- and the
+facade then collects its names. Submodule first: X stops at its import line to
+run `memory_db`, which immediately asks X for names it has not defined yet.
+
+So the direction that fails is the one where the import is `from X import
+name` rather than `import X`. Nineteen modules are affected, not one: every
+submodule `memory_db` re-exports by name.
+
+Invisible through the MCP server, which always imports the facade. It bites a
+test module, a script, `python -m`, a debugger session, and any future change
+that drops the facade import -- and reads as a broken install rather than an
+import-order constraint.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_MEMOIRE = Path(__file__).resolve().parents[1] / "src" / "token_savior" / "memory"
+MODULES = sorted(
+    p.stem for p in _MEMOIRE.glob("*.py")
+    if p.stem != "__init__"
+)
+
+
+def test_the_module_list_is_not_empty() -> None:
+    """Guards the parametrisation itself: an empty glob would pass silently."""
+    assert len(MODULES) > 15, MODULES
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_submodule_imports_without_the_facade(module: str) -> None:
+    resultat = subprocess.run(
+        [sys.executable, "-c", f"import token_savior.memory.{module}"],
+        capture_output=True, text=True, env=dict(os.environ), timeout=120,
+        check=False,
+    )
+    assert resultat.returncode == 0, resultat.stderr.strip().splitlines()[-1:]
+
+
+def test_the_facade_still_re_exports_everything() -> None:
+    """Breaking the cycle must not empty `memory_db`.
+
+    The facade exists so that rebinding `memory_db.MEMORY_DB_PATH` reaches
+    every submodule that opens a connection. A fix that made the submodules
+    importable by cutting the re-exports would take that away.
+    """
+    programme = (
+        "from token_savior import memory_db\n"
+        "for nom in ('observation_save', 'observation_search', 'session_end',\n"
+        "            'get_stats', 'event_save', 'MEMORY_DB_PATH', 'get_db'):\n"
+        "    assert hasattr(memory_db, nom), nom\n"
+    )
+    resultat = subprocess.run(
+        [sys.executable, "-c", programme],
+        capture_output=True, text=True, env=dict(os.environ), timeout=120,
+        check=False,
+    )
+    assert resultat.returncode == 0, resultat.stderr
+
+
+def test_the_path_override_still_reaches_a_submodule(tmp_path) -> None:
+    """Rebinding the facade's path must still steer a submodule's connection."""
+    cible = tmp_path / "impose.db"
+    programme = (
+        "from token_savior import memory_db\n"
+        "from token_savior.memory import observations\n"
+        f"memory_db.MEMORY_DB_PATH = {str(cible)!r}\n"
+        "observations.observation_save(None, '/tmp/p', 'insight', 't', 'c')\n"
+    )
+    resultat = subprocess.run(
+        [sys.executable, "-c", programme],
+        capture_output=True, text=True, env=dict(os.environ), timeout=120,
+        check=False,
+    )
+    assert resultat.returncode == 0, resultat.stderr
+    assert cible.exists(), resultat.stderr


### PR DESCRIPTION
```
$ python -c "import token_savior.memory.observations"
ImportError: cannot import name '_CORRUPTION_MARKERS' from partially initialized
module 'token_savior.memory.observations' (most likely due to a circular import)

$ python -c "import token_savior.memory_db, token_savior.memory.observations"
ok
```

**Nineteen** submodules fail that way, not one — every module `memory_db` re-exports by name.

### Why it resolves in one direction only

The cycle is `memory.X` → `memory_db` → `memory.X`.

* **Facade first** — `memory_db` runs, reaches `from token_savior.memory.X import (...)`, X runs to completion (its own `from token_savior import memory_db` binds the partially initialised *module object*, which is fine because it is only dereferenced at call time), and the facade collects its names.
* **Submodule first** — X stops at its import line to run `memory_db`, which immediately asks X for names it has not defined yet.

The direction that fails is the one importing *names* rather than a *module*.

Invisible through the MCP server, which always goes through the facade. It bites a test module, a script, `python -m`, a debugger session, and any later change that drops the facade import — and reads as a broken install rather than an import-order constraint.

### Fix

Cut the cycle in one place rather than at the call sites. `memory/_facade.py` is a lazy handle that imports nothing at module level and resolves `token_savior.memory_db` on first attribute access, by which time both modules exist. The 19 modules change one import line each; no call site moves.

Resolving per access is also what keeps the override working: rebinding `memory_db.MEMORY_DB_PATH` — which `conftest` does session-wide and 31 test modules do per case — still reaches every submodule, because nothing holds a copy of anything.

### Tests

23 tests. 19 verified red on `main` — one per submodule, each importing it in a clean interpreter. The parametrisation is generated from the directory, so a fourth test asserts the list is not empty; an empty glob would otherwise pass silently.

Two more were green before and after, and are the ones that stop this from being fixed the wrong way:

* the facade still re-exports its names — a fix that made submodules importable by cutting the re-exports would break the single point rebinding relies on;
* rebinding `memory_db.MEMORY_DB_PATH` still steers a submodule's connection.

Suite: **2759 passed, 14 skipped**. `ruff==0.16.0` clean (import blocks re-sorted by `ruff --fix`, which accounts for the churn beyond the one-line swaps).

Closes #78
