### PR TITLE
fix(init): honor CODEX_HOME, and make CLAUDE_CONFIG_DIR reachable

### DIFF
--- a/src/token_savior/cli_init/__init__.py
+++ b/src/token_savior/cli_init/__init__.py
@@ -42,8 +42,12 @@ else:
 # --------------------------------------------------------------------------- #
 # Helpers                                                                     #
 # --------------------------------------------------------------------------- #
-def _detect_agent(home: Path) -> str | None:
-    """Return the first agent whose install marker already exists."""
+def _detect_agent(home: Path | None = None) -> str | None:
+    """Return the first agent whose install marker already exists.
+
+    `home` stays optional so that, unpinned, `detection_path` may consult the
+    agent's own config-root variable (CLAUDE_CONFIG_DIR, CODEX_HOME).
+    """
     for agent in SUPPORTED_AGENTS:
         try:
             if detection_path(agent, home).exists():
@@ -205,7 +209,13 @@ def run(argv: list[str] | None = None, *,
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    home = Path(args.home) if args.home else Path.home()
+    # Left as None when unset, deliberately. Resolving Path.home() here and
+    # passing it down pinned the answer before anyone could ask about
+    # CLAUDE_CONFIG_DIR or CODEX_HOME, so the support added for the former was
+    # never reachable through this command -- `ts init` reported
+    # `Target: ~/.claude/settings.json` with CLAUDE_CONFIG_DIR pointing
+    # elsewhere. The path helpers fall back to Path.home() themselves.
+    home = Path(args.home) if args.home else None
     cwd = Path(args.cwd) if args.cwd else Path.cwd()
     ts_root = Path(args.ts_root) if args.ts_root else _REPO_ROOT
 

--- a/src/token_savior/cli_init/agent_paths.py
+++ b/src/token_savior/cli_init/agent_paths.py
@@ -70,12 +70,54 @@ def _local_settings(agent: str, cwd: Path) -> Path:
     raise ValueError(f"unsupported agent: {agent}")
 
 
-def detection_path(agent: str, home: Path) -> Path:
+# --------------------------------------------------------------------------- #
+# Relocatable config roots                                                    #
+# --------------------------------------------------------------------------- #
+# Claude Code and Codex both let the user move their entire config root. Probed
+# against codex-cli 0.145.0: with CODEX_HOME set, `codex doctor` reports that
+# directory as CODEX_HOME and loads its `config.toml` from it.
+#
+# CODEX_HOME was read in exactly one place in this codebase -- as a "which
+# client am I" signal for stats -- and every Codex path was hardcoded to
+# ~/.codex, so `ts init --agent codex` wrote hooks.json where Codex never looks
+# and the hooks silently did nothing.
+_VARIABLE_RACINE = {
+    "claude": "CLAUDE_CONFIG_DIR",
+    "codex": "CODEX_HOME",
+}
+# Name of the settings file directly under a relocated root (no dot-directory:
+# the variable already points at the config root itself).
+_FICHIER_SOUS_RACINE = {"claude": "settings.json", "codex": "hooks.json"}
+# Name of the install marker under that same root. Codex's hooks.json only
+# exists once `ts init` has run, so its marker is config.toml.
+_MARQUEUR_SOUS_RACINE = {"claude": "settings.json", "codex": "config.toml"}
+
+
+def _config_root(agent: str) -> Path | None:
+    """The agent's own config-root override, when the environment sets one."""
+    variable = _VARIABLE_RACINE.get(agent)
+    if not variable:
+        return None
+    valeur = os.environ.get(variable, "").strip()
+    return Path(valeur) if valeur else None
+
+
+def detection_path(agent: str, home: Path | None = None) -> Path:
     """Return the file whose existence marks an installed agent.
 
     Usually the global settings file itself — except Codex, whose hooks.json
     only exists after `ts init` has run; its install marker is config.toml.
+
+    Honors the agent's config-root variable when `home` is not pinned, like
+    `settings_path`. Without it a relocated agent reads as *not installed*: the
+    marker lives under the moved root, and looking for it under `~` finds
+    nothing, so `ts init` skips an agent that is installed and configured.
     """
+    if home is None:
+        racine = _config_root(agent)
+        if racine is not None:
+            return racine / _MARQUEUR_SOUS_RACINE[agent]
+    home = home or Path.home()
     if agent == "codex":
         return home / ".codex" / "config.toml"
     return _global_settings(agent, home)
@@ -86,13 +128,13 @@ def settings_path(agent: str, scope: Scope = "global", *, home: Path | None = No
     """Return the settings.json path for the given agent and scope.
 
     `home` and `cwd` overrides are exposed for tests so we never touch the
-    real user filesystem. Claude Code honors the CLAUDE_CONFIG_DIR environment
-    variable for its global config root; an explicit `home` override wins.
+    real user filesystem; an explicit `home` wins over the environment, which
+    is what keeps the suite from depending on the developer's own setup.
     """
-    if scope == "global" and agent == "claude" and home is None:
-        config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
-        if config_dir:
-            return Path(config_dir) / "settings.json"
+    if scope == "global" and home is None:
+        racine = _config_root(agent)
+        if racine is not None:
+            return racine / _FICHIER_SOUS_RACINE[agent]
     home = home or Path.home()
     cwd = cwd or Path.cwd()
     if scope == "global":

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -17,6 +17,7 @@ from token_savior.cli_init import (
 )
 from token_savior.cli_init.agent_paths import (
     SUPPORTED_AGENTS,
+    detection_path,
     hook_config_paths,
     settings_path,
 )
@@ -171,6 +172,113 @@ def test_settings_path_explicit_home_wins_over_claude_config_dir(
 ) -> None:
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude2"))
     assert settings_path("claude", "global", home=tmp_path) == tmp_path / ".claude" / "settings.json"
+
+
+# --- Config-root environment variables ----------------------------------- #
+#
+# Claude Code and Codex both let the user move their whole config root:
+# CLAUDE_CONFIG_DIR and CODEX_HOME. Probed against codex-cli 0.145.0 -- with
+# CODEX_HOME set, `codex doctor` reports that directory as CODEX_HOME and loads
+# `config.toml` from it.
+#
+# Token Savior read CODEX_HOME in exactly one place, as a "which client am I"
+# signal for stats, and hardcoded ~/.codex for every path. CLAUDE_CONFIG_DIR was
+# honoured in `settings_path`, but only on the `home is None` branch, which
+# `run()` never took because it resolved `Path.home()` before calling. So
+# `ts init` wrote hooks where neither agent would ever read them, and reported
+# a relocated agent as not installed.
+
+
+def test_settings_path_codex_global_honors_codex_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex2"))
+    assert settings_path("codex", "global") == tmp_path / "codex2" / "hooks.json"
+
+
+def test_settings_path_claude_global_still_honors_claude_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude2"))
+    assert settings_path("claude", "global") == tmp_path / "claude2" / "settings.json"
+
+
+def test_detection_path_codex_honors_codex_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Otherwise a relocated Codex reads as "not installed"."""
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex2"))
+    assert detection_path("codex") == tmp_path / "codex2" / "config.toml"
+
+
+def test_detection_path_claude_honors_claude_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude2"))
+    assert detection_path("claude") == tmp_path / "claude2" / "settings.json"
+
+
+@pytest.mark.parametrize(
+    ("agent", "variable", "attendu"),
+    [("codex", "CODEX_HOME", ".codex"), ("claude", "CLAUDE_CONFIG_DIR", ".claude")],
+)
+def test_an_explicit_home_ignores_the_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    agent: str, variable: str, attendu: str,
+) -> None:
+    """An explicit `home` pins the answer, so tests stay environment-independent.
+
+    Without this rule, `_detect_agent(tmp_path)` would start seeing the
+    developer's own relocated agent and the suite would pass or fail depending
+    on who ran it.
+    """
+    monkeypatch.setenv(variable, str(tmp_path / "ailleurs"))
+    assert settings_path(agent, "global", home=tmp_path).is_relative_to(tmp_path / attendu)
+    assert detection_path(agent, tmp_path).is_relative_to(tmp_path / attendu)
+
+
+def test_settings_path_codex_local_ignores_codex_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Project scope stays project-relative: CODEX_HOME is a *user* config root."""
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex2"))
+    assert settings_path("codex", "local", cwd=tmp_path) == tmp_path / ".codex" / "hooks.json"
+
+
+@pytest.mark.parametrize(
+    ("agent", "variable", "fichier"),
+    [("codex", "CODEX_HOME", "hooks.json"),
+     ("claude", "CLAUDE_CONFIG_DIR", "settings.json")],
+)
+def test_ts_init_targets_the_relocated_config_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    agent: str, variable: str, fichier: str,
+) -> None:
+    """The end-to-end gap: `run()` resolved Path.home() before asking.
+
+    This is the case the unit tests above could not catch, and the reason
+    CLAUDE_CONFIG_DIR support has been inert since it was added.
+    """
+    racine = tmp_path / "racine"
+    racine.mkdir()
+    monkeypatch.setenv(variable, str(racine))
+    rc = run(["--agent", agent, "--global", "--dry-run", "--ts-root", str(REPO_ROOT)])
+    assert rc == 0
+    sortie = capsys.readouterr().out
+    assert f"Target: {racine / fichier}" in sortie, sortie[:400]
+
+
+def test_ts_init_home_flag_wins_over_the_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "ailleurs"))
+    fake_home = tmp_path / "maison"
+    fake_home.mkdir()
+    rc = run(["--agent", "claude", "--global", "--dry-run",
+              "--home", str(fake_home), "--ts-root", str(REPO_ROOT)])
+    assert rc == 0
+    sortie = capsys.readouterr().out
+    assert f"Target: {fake_home / '.claude' / 'settings.json'}" in sortie, sortie[:400]
 
 
 def test_hook_config_paths_claude_has_both() -> None:


### PR DESCRIPTION
Started as "Codex support for the `CLAUDE_CONFIG_DIR` treatment", turned out to be one root cause with three symptoms — including the `CLAUDE_CONFIG_DIR` support itself, which has never worked through the CLI.

### `CODEX_HOME` was never a path

Read once in the whole tree, as a "which client am I" signal for stats:

```python
if os.environ.get("CODEX_HOME") or os.environ.get("CODEX_SANDBOX"):
    return "codex"
```

Every Codex path was hardcoded to `~/.codex`. Codex does relocate — probed against **codex-cli 0.145.0** with a sentinel config:

```
$ CODEX_HOME=/tmp/probe codex doctor
      CODEX_HOME    /private/tmp/probe (dir)
      model         probe-sentinel-model · openai
      config.toml   /private/tmp/probe/config.toml
```

So `ts init --agent codex` wrote `hooks.json` where Codex never looks, and the hooks silently did nothing — the same failure shape as #64.

### `CLAUDE_CONFIG_DIR` was unreachable

`settings_path` honours it only when `home is None`, and `run()` resolved the home first:

```python
home = Path(args.home) if args.home else Path.home()
target = settings_path(agent, scope, home=home, cwd=cwd)
```

so the branch never fired:

```
$ CLAUDE_CONFIG_DIR=/tmp/probe/claudecfg ts init --agent claude --global --dry-run
Target: /Users/andre/.claude/settings.json
```

The test that shipped with that support calls `settings_path()` directly — the one caller that does leave `home` unset. Nothing covered the path a user runs. My own miss, from the PR that added it.

### `detection_path` honoured neither

Worse than a wrong write target: an agent whose config lives only under a relocated root reads as **not installed**, so `ts init` with no `--agent` picks a different agent or refuses.

### Fix

Leave `home` as `None` unless `--home` is given, and look the config root up in one place keyed by agent. An explicit `home` still wins — that rule is what keeps the suite from depending on whether the developer has `CODEX_HOME` set, and `_detect_agent(tmp_path)` from finding their real agents. Project scope stays project-relative: these are *user* config roots.

Verified end to end afterwards, both directions:

```
CODEX_HOME=/tmp/.../codexcfg  ->  Target: /tmp/.../codexcfg/hooks.json
CODEX_HOME unset              ->  Target: /Users/andre/.codex/hooks.json
```

### Tests

12 tests, 5 verified red on `main`:

* `settings_path("codex")` honours `CODEX_HOME`;
* `detection_path` honours `CODEX_HOME` and `CLAUDE_CONFIG_DIR`;
* **the two that matter** — `ts init --dry-run` targets the relocated root, for both agents. These are the end-to-end cases the existing unit test could not catch.

Seven were green before and after and pin the boundaries: an explicit `home` beats the environment for both agents (parametrised), `--home` beats it at the CLI, local scope ignores it, and the original `settings_path` + `CLAUDE_CONFIG_DIR` unit behaviour is unchanged.

Suite: **2729 passed, 14 skipped**. `ruff==0.16.0` clean.

Closes #88
