### PR TITLE
fix(memory): the observation title never reached its vector

### DIFF
--- a/src/token_savior/memory/embeddings.py
+++ b/src/token_savior/memory/embeddings.py
@@ -155,6 +155,25 @@ def _serialize_vec(vec: list[float]) -> Any | None:
         return None
 
 
+def texte_indexable(titre: str | None, corps: str | None) -> str | None:
+    """Texte reellement embarque pour une observation : titre PUIS corps.
+
+    Le titre porte la formulation courte -- « Redemarrer nginx » -- pendant que
+    le corps porte la commande -- « systemctl restart nginx apres modification
+    du vhost ». Les indexer separement n'a pas de sens : une requete formulee
+    comme un titre (« redemarrer le serveur web ») est alors comparee a un
+    texte d'ou le mot qu'elle demande est absent, et le voisin correct sort
+    derriere des observations sans rapport.
+
+    Recette unique, appelee par les trois sites qui indexent (save, update,
+    backfill), pour qu'elle ne puisse pas diverger de l'un a l'autre. Un
+    changement ICI change ce que veulent dire les vecteurs deja stockes : voir
+    ``backfill_obs_vectors(rebuild=True)``.
+    """
+    morceaux = [m.strip() for m in (titre, corps) if m and m.strip()]
+    return "\n".join(morceaux) or None
+
+
 def maybe_index_obs(obs_id: int, text: str | None, conn: Any) -> bool:
     """Embed ``text`` and upsert an obs_vectors row using ``conn``.
 
@@ -174,8 +193,15 @@ def maybe_index_obs(obs_id: int, text: str | None, conn: Any) -> bool:
     if blob is None:
         return False
     try:
+        # vec0 refuse `INSERT OR REPLACE` sur sa cle primaire -- il leve
+        # « UNIQUE constraint failed on obs_vectors primary key » au lieu de
+        # remplacer. Le DELETE prealable est donc la seule forme d'upsert
+        # disponible, et sans lui toute reindexation (rafraichissement apres
+        # une mise a jour de contenu, backfill(rebuild=True)) echouait en
+        # silence : l'exception etait avalee et l'ancien vecteur restait.
+        conn.execute("DELETE FROM obs_vectors WHERE obs_id = ?", (obs_id,))
         conn.execute(
-            "INSERT OR REPLACE INTO obs_vectors(obs_id, embedding) VALUES (?, ?)",
+            "INSERT INTO obs_vectors(obs_id, embedding) VALUES (?, ?)",
             (obs_id, blob),
         )
         return True
@@ -191,6 +217,7 @@ def backfill_obs_vectors(
     project_root: str | None = None,
     *,
     limit: int = 500,
+    rebuild: bool = False,
 ) -> dict[str, Any]:
     """Backfill obs_vectors for observations that lack a vector row.
 
@@ -201,6 +228,14 @@ def backfill_obs_vectors(
       * total    : total eligible obs
       * pending  : total - (previously_indexed + indexed_this_run)
       * reason   : filled when status != "ok"
+
+    ``rebuild=True`` re-embeds rows that ALREADY have a vector, instead of
+    only filling the gaps. A vector is only comparable to vectors built from
+    the same text recipe (:func:`texte_indexable`); a row indexed before the
+    recipe changed keeps answering with the old meaning, and nothing in the
+    schema records which recipe produced it. There is no automatic migration
+    on purpose -- dropping the stale rows at startup would leave vector
+    recall dead until someone ran this by hand.
     """
     from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
     from token_savior.memory._facade import memory_db
@@ -241,21 +276,25 @@ def backfill_obs_vectors(
                     "reason": "obs_vectors table missing (extension not loaded)",
                 }
 
+            deja_indexes = "" if rebuild else \
+                "  AND id NOT IN (SELECT obs_id FROM obs_vectors) "
             rows = conn.execute(
-                f"SELECT id, COALESCE(narrative, content) AS text "
+                f"SELECT id, title, COALESCE(narrative, content) AS text "
                 f"FROM observations WHERE archived=0 {where_proj} "
-                f"  AND id NOT IN (SELECT obs_id FROM obs_vectors) "
+                f"{deja_indexes}"
                 f"ORDER BY id DESC LIMIT ?",
                 base_params + [int(limit)],
             ).fetchall()
 
             indexed = 0
             for r in rows:
-                if maybe_index_obs(r["id"], r["text"], conn):
+                if maybe_index_obs(r["id"], texte_indexable(r["title"], r["text"]), conn):
                     indexed += 1
             conn.commit()
 
-        pending = max(0, total - prev_indexed - indexed)
+        # En rebuild les lignes re-indexees etaient deja comptees dans
+        # prev_indexed : les additionner ferait disparaitre le reste a faire.
+        pending = max(0, total - (prev_indexed if rebuild else prev_indexed + indexed))
         return {
             "status": "ok", "indexed": indexed, "total": total,
             "pending": pending, "previously_indexed": prev_indexed,

--- a/src/token_savior/memory/observations.py
+++ b/src/token_savior/memory/observations.py
@@ -237,8 +237,13 @@ def observation_save(
             obs_id = cur.lastrowid
             _supersede_stale(conn, semantic, obs_id, now)
             try:
-                from token_savior.memory.embeddings import maybe_index_obs
-                maybe_index_obs(obs_id, narrative or content, conn)
+                from token_savior.memory.embeddings import (
+                    maybe_index_obs,
+                    texte_indexable,
+                )
+                maybe_index_obs(
+                    obs_id, texte_indexable(title, narrative or content), conn,
+                )
             except Exception:
                 pass
             conn.commit()
@@ -725,14 +730,19 @@ def observation_update(
             from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
             if VECTOR_SEARCH_AVAILABLE:
                 try:
-                    from token_savior.memory.embeddings import maybe_index_obs
+                    from token_savior.memory.embeddings import (
+                        maybe_index_obs,
+                        texte_indexable,
+                    )
                     row = conn.execute(
-                        "SELECT COALESCE(narrative, content) AS text "
+                        "SELECT title, COALESCE(narrative, content) AS text "
                         "FROM observations WHERE id=?",
                         (obs_id,),
                     ).fetchone()
                     if row is not None:
-                        maybe_index_obs(obs_id, row["text"], conn)
+                        maybe_index_obs(
+                            obs_id, texte_indexable(row["title"], row["text"]), conn,
+                        )
                 except Exception as exc:
                     print(
                         f"[token-savior:memory] obs_vectors refresh on "

--- a/src/token_savior/server_handlers/memory.py
+++ b/src/token_savior/server_handlers/memory.py
@@ -472,7 +472,8 @@ def _mh_memory_vector_reindex(args: dict[str, Any]) -> str:
     from token_savior.memory.embeddings import backfill_obs_vectors
     root = _resolve_memory_project(args)
     limit = int(args.get("limit", 500))
-    res = backfill_obs_vectors(project_root=root, limit=limit)
+    rebuild = bool(args.get("rebuild", False))
+    res = backfill_obs_vectors(project_root=root, limit=limit, rebuild=rebuild)
     status = res.get("status", "?")
     if status != "ok":
         reason = res.get("reason", "unknown")

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -1219,6 +1219,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
                 "project_root": {"type": "string", "description": "Filter by project (where applicable)."},
                 "limit": {"type": "integer", "description": "Pagination/limit (where applicable)."},
                 "dry_run": {"type": "boolean", "description": "Preview-only mode for sweeps/garbage collectors."},
+                "rebuild": {"type": "boolean", "description": "vector_reindex: re-embed rows that already have a vector, not just the missing ones."},
             },
             "additionalProperties": True,
         },

--- a/tests/test_memory_vector_indexation.py
+++ b/tests/test_memory_vector_indexation.py
@@ -9,6 +9,7 @@ table (no vec0 extension required).
 
 from __future__ import annotations
 
+import itertools
 from pathlib import Path
 from unittest.mock import patch
 
@@ -104,7 +105,13 @@ class TestObservationSaveVectorHookSimulatedAvailable:
         assert row["obs_id"] == oid
         assert row["n"] == 3072
 
-    def test_embed_receives_narrative_preferred_over_content(self, monkeypatch):
+    def test_embed_receives_title_then_narrative_preferred_over_content(self, monkeypatch):
+        """The title is part of the indexed text; narrative still wins over content.
+
+        Indexing the body alone leaves the short formulation out of the vector,
+        so a query phrased like a title is compared against a text that does
+        not contain what it asks for (see tests/test_vector_distance_floor.py).
+        """
         monkeypatch.setattr(db_core, "VECTOR_SEARCH_AVAILABLE", True)
         captured: dict[str, str] = {}
 
@@ -117,10 +124,16 @@ class TestObservationSaveVectorHookSimulatedAvailable:
         _create_plain_obs_vectors_table()
 
         _save(title="t", content="CONTENT", narrative="NARRATIVE")
-        assert captured["text"] == "NARRATIVE"
+        assert captured["text"] == "t\nNARRATIVE"
 
         _save(title="t2", content="CONTENT2", narrative=None)
-        assert captured["text"] == "CONTENT2"
+        assert captured["text"] == "t2\nCONTENT2"
+
+    def test_texte_indexable_tolerates_missing_parts(self):
+        assert embeddings.texte_indexable("titre", "corps") == "titre\ncorps"
+        assert embeddings.texte_indexable(None, "corps") == "corps"
+        assert embeddings.texte_indexable("titre", None) == "titre"
+        assert embeddings.texte_indexable("  ", "") is None
 
 
 class TestBackfillFunction:
@@ -187,6 +200,79 @@ class TestBackfillFunction:
         assert n == 3
         # Sanity: the ids match.
         assert {o1, o2, o3} == set(range(min(o1, o2, o3), max(o1, o2, o3) + 1))
+
+    def test_rebuild_reindexes_rows_that_already_have_a_vector(self, monkeypatch):
+        """Without rebuild, a row indexed under an older text recipe is skipped.
+
+        Nothing in the schema records which recipe produced a stored vector, so
+        the only way to bring old rows onto the current one is to re-embed them
+        on demand.
+        """
+        monkeypatch.setattr(db_core, "VECTOR_SEARCH_AVAILABLE", True)
+        monkeypatch.setattr(embeddings, "_load_model", lambda: object())
+        seen: list[str] = []
+        monkeypatch.setattr(
+            embeddings, "embed", lambda text, **kw: seen.append(text or "") or [0.0] * 768
+        )
+        monkeypatch.setattr(embeddings, "_serialize_vec", lambda vec: b"\x00" * 3072)
+        _create_plain_obs_vectors_table()
+
+        _save(title="a", content="aa")
+        _save(title="b", content="bb")
+
+        seen.clear()
+        res = embeddings.backfill_obs_vectors(project_root=PROJECT, limit=10)
+        assert res["indexed"] == 0, "les deux lignes ont deja un vecteur"
+        assert seen == []
+
+        res = embeddings.backfill_obs_vectors(project_root=PROJECT, limit=10, rebuild=True)
+        assert res["status"] == "ok"
+        assert res["indexed"] == 2
+        assert res["pending"] == 0
+        assert sorted(seen) == ["a\naa", "b\nbb"]
+
+
+class TestReindexationSurUneVraieTableVec0:
+    """Les autres tests de ce fichier utilisent une table obs_vectors ORDINAIRE.
+
+    C'est ce qui rend la suite executable sur un hote sans sqlite-vec, mais une
+    table ordinaire accepte `INSERT OR REPLACE` -- vec0 le refuse. Le cas
+    « ce vecteur existe deja, remplace-le » n'etait donc couvert nulle part.
+    """
+
+    def test_maybe_index_obs_remplace_un_vecteur_existant(self, monkeypatch):
+        """Reindexer une observation deja indexee doit reussir, pas echouer.
+
+        observation_update() rafraichit le vecteur quand le contenu change, et
+        backfill_obs_vectors(rebuild=True) reindexe tout le monde : les deux
+        passent par ce chemin, et tous deux echouaient en silence sur une vraie
+        table vec0 (`UNIQUE constraint failed on obs_vectors primary key`),
+        maybe_index_obs avalant l'exception pour rendre False.
+        """
+        pytest.importorskip("sqlite_vec")
+        monkeypatch.setattr(db_core, "VECTOR_SEARCH_AVAILABLE", True)
+        # Un vecteur distinct par appel : _save() en consomme deja un.
+        appels = itertools.count()
+        monkeypatch.setattr(
+            embeddings, "embed",
+            lambda text, **kw: [float(next(appels))] + [0.0] * 767,
+        )
+
+        oid = _save(title="cible", content="corps")
+        with memory_db.db_session() as conn:
+            if not conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE name='obs_vectors' AND sql LIKE '%vec0%'"
+            ).fetchone():
+                pytest.skip("obs_vectors n'est pas une table vec0 sur cet hote")
+            assert embeddings.maybe_index_obs(oid, "premiere version", conn) is True
+            avant = conn.execute(
+                "SELECT embedding FROM obs_vectors WHERE obs_id=?", (oid,)
+            ).fetchone()[0]
+            assert embeddings.maybe_index_obs(oid, "seconde version", conn) is True
+            apres = conn.execute(
+                "SELECT embedding FROM obs_vectors WHERE obs_id=?", (oid,)
+            ).fetchone()[0]
+        assert avant != apres, "le vecteur stocke n'a pas ete remplace"
 
 
 class TestVectorReindexHandler:

--- a/tests/test_vector_distance_floor.py
+++ b/tests/test_vector_distance_floor.py
@@ -112,3 +112,47 @@ def test_le_seuil_en_fusion_n_est_jamais_plus_strict_que_seul() -> None:
         f"{_DISTANCE_MAX_SEULE} : un voisin cautionne par le lexical serait "
         "plus exige qu'un voisin sans aucune corroboration."
     )
+
+
+def test_le_titre_de_l_observation_atteint_le_vecteur(base) -> None:
+    """L'exemple pathologique du docstring, mesure sur le leg vectoriel seul.
+
+    « redemarrer le serveur web » classait `Certificat SSL expire` DEVANT
+    `Redemarrer nginx`. Le classement n'est pas arbitraire : le vecteur d'une
+    observation est calcule sur `narrative or content`, donc sur
+    « systemctl restart nginx apres modification du vhost » -- le titre, ou
+    le mot « redemarrer » figure en toutes lettres, n'atteint jamais
+    l'embedding. La requete est comparee a un texte qui ne contient pas ce
+    qu'elle demande.
+
+    Le leg lexical masque le defaut de bout en bout (observations_fts indexe
+    le titre, lui), donc la mesure se fait ici sur `vec_search_rows`, ou le
+    vecteur est le seul signal -- exactement le cas que _DISTANCE_MAX_SEULE
+    est cense servir.
+
+    Seul test du fichier qui exige vraiment la pile vectorielle : la CI
+    installe `[dev,mcp]`, sans `memory-vector`, donc sqlite-vec et fastembed y
+    sont absents et les autres tests d'ici passent par le seul leg lexical.
+    """
+    from token_savior.db_core import VECTOR_SEARCH_AVAILABLE
+    from token_savior.memory.embeddings import embed, is_available
+    from token_savior.memory.search import vec_search_rows
+
+    if not (VECTOR_SEARCH_AVAILABLE and is_available()):
+        pytest.skip("pile vectorielle absente (sqlite-vec / fastembed)")
+
+    with memory_db.db_session() as conn:
+        voisins = vec_search_rows(
+            conn, embed("redemarrer le serveur web", as_query=True), base, limit=5,
+        )
+    par_titre = {v["title"]: v["distance"] for v in voisins}
+
+    assert voisins[0]["title"] == "Redemarrer nginx", (
+        "le voisin le plus proche de « redemarrer le serveur web » devrait "
+        f"etre `Redemarrer nginx` : {[(v['title'], round(v['distance'], 4)) for v in voisins]}"
+    )
+    assert par_titre["Redemarrer nginx"] <= _DISTANCE_MAX_SEULE, (
+        f"la bonne reponse sort a {par_titre['Redemarrer nginx']:.4f}, au-dela "
+        f"du plancher {_DISTANCE_MAX_SEULE} : le plancher ecarte la reponse "
+        "correcte en meme temps que le bruit."
+    )


### PR DESCRIPTION
## What this fixes

`maybe_index_obs` embeds `narrative or content`. The observation **title never reaches the vector**.

That is the mechanism behind the example in the docstring of `tests/test_vector_distance_floor.py`. On the five-observation corpus in that file, measured through the product's own `embed()` and `vec_search_rows()`:

```
query: 'redemarrer le serveur web'
    0.9415  Certificat SSL expire
    0.9757  Relancer les tests
    0.9831  Nommage des branches
    0.9896  Ne jamais supprimer en masse en prod
    1.0037  Redemarrer nginx          <- the correct answer, last
```

The ranking is not arbitrary. The vector for `Redemarrer nginx` was built from `"systemctl restart nginx apres modification du vhost"` alone — the word the query asks for is not in the indexed text. The 0.90 floor then drops the correct answer along with the noise: the whole list is empty on the solo path.

Indexing `title` then body:

```
query: 'redemarrer le serveur web'
    0.8456  Redemarrer nginx          <- first, and inside the floor
    0.9123  Ne jamais supprimer en masse en prod
    0.9537  Certificat SSL expire
```

The lexical leg hides this end to end — `observations_fts` does index the title, so `observation_search()` returns the right answer anyway. The new test therefore measures `vec_search_rows` directly, which is the case `_DISTANCE_MAX_SEULE` exists to serve.

On a corpus that is not five rows: 122 observations accumulated over months of real work on an unrelated project, each observation's own recall trigger used as the query.

| | content only (today) | title + content |
|---|---|---|
| top-1 | 91.8% | **94.3%** |
| top-3 | 95.9% | **97.5%** |
| MRR | 0.941 | **0.960** |
| worst rank | 95 | **38** |

The recipe now lives in one function, `texte_indexable()`, called by the three sites that index (save, update, backfill), so it cannot drift between them.

## Second defect, found while testing the first

`vec0` refuses `INSERT OR REPLACE` on its primary key. It raises `UNIQUE constraint failed on obs_vectors primary key` instead of replacing:

```
INSERT OR REPLACE: FAIL UNIQUE constraint failed on obs_vectors primary key
DELETE + INSERT:   ok
```

So **every re-index of an observation that already has a vector has been failing**, with `maybe_index_obs` swallowing the exception and returning `False`. `observation_update()` refreshes the vector when the content changes — on a real vec0 table it never did; the stale vector stayed. The existing tests could not see it because they build `obs_vectors` as an ordinary table, which does accept `INSERT OR REPLACE`. The new test asks for a real vec0 table and skips where sqlite-vec is absent.

## What this does NOT do

- **The thresholds are untouched.** `_DISTANCE_MAX_FUSION` and `_DISTANCE_MAX_SEULE` stay at 0.90, and the tests you added in ecfcd69 stay as they are. See the issue comment for why the measurement supports leaving them alone.
- **It does not migrate vectors already stored.** They keep the old recipe, and nothing in the schema records which recipe produced a vector. `memory_vector_reindex(rebuild=true)` re-embeds rows that already have one — that is the whole of the new `rebuild` flag. There is deliberately no automatic migration: dropping stale rows at startup would leave vector recall dead until someone ran a backfill by hand, which is worse than a mixed index. If you would rather it self-heal, say so and I will add the recipe marker.
- **It does not fix the ranking pathology in general.** It removes this cause of it. A query far from both the title and the body still ranks on the body alone.
- **No CHANGELOG entry** — post-4.20.0 fixes have not been carrying one; happy to add it wherever you want it.

## Verification

- `tests/test_vector_distance_floor.py::test_le_titre_de_l_observation_atteint_le_vecteur` — red before the change (`Certificat SSL expire` first, `Redemarrer nginx` at 1.0037 beyond the floor), green after, unchanged between the two runs.
- `tests/test_memory_vector_indexation.py::TestReindexationSurUneVraieTableVec0` — red before, green after, same test text.
- `test_embed_receives_narrative_preferred_over_content` was asserting the old recipe; it is updated to assert the new one and renamed accordingly.
- 2826 passed, 5 skipped. `ruff check src tests` clean.

Raised out of #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
