### PR TITLE
fix(stats): one answer per process for TOKEN_SAVIOR_STATS_DIR

### DIFF
--- a/src/token_savior/dashboard.py
+++ b/src/token_savior/dashboard.py
@@ -7,9 +7,11 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from urllib.parse import urlparse
 
-DEFAULT_STATS_DIR = Path(
-    os.environ.get("TOKEN_SAVIOR_STATS_DIR", "~/.local/share/token-savior")
-).expanduser()
+from token_savior.telemetry import stats_dir as _stats_dir
+
+# `DEFAULT_STATS_DIR` etait une constante calculee a l'import ET une valeur par
+# defaut d'argument, donc figee deux fois. Les deux fonctions qui l'utilisaient
+# prennent desormais `None` et demandent le repertoire au moment de lire (#90).
 HOST = os.environ.get("TOKEN_SAVIOR_DASHBOARD_HOST", "127.0.0.1")
 PORT = int(os.environ.get("TOKEN_SAVIOR_DASHBOARD_PORT", "8921"))
 INCLUDE_TMP_PROJECTS = os.environ.get("TOKEN_SAVIOR_INCLUDE_TMP_PROJECTS", "").lower() in {
@@ -254,7 +256,8 @@ def collect_memory_engine_data() -> dict:
     }
 
 
-def collect_dashboard_data(stats_dir: Path = DEFAULT_STATS_DIR) -> dict:
+def collect_dashboard_data(stats_dir: Path | None = None) -> dict:
+    stats_dir = _stats_dir() if stats_dir is None else stats_dir
     files = sorted(stats_dir.glob("*.json")) if stats_dir.exists() else []
     projects = []
     recent_sessions = []
@@ -986,7 +989,7 @@ if __name__ == "__main__":
 # ---------------------------------------------------------------------------
 
 
-def gain_report(stats_dir: Path = DEFAULT_STATS_DIR, project: str | None = None) -> dict:
+def gain_report(stats_dir: Path | None = None, project: str | None = None) -> dict:
     """Savings for every project, or for one, reusing the dashboard collector.
 
     Scripts wanting these numbers previously had to run the dashboard or parse

--- a/src/token_savior/query_api.py
+++ b/src/token_savior/query_api.py
@@ -2772,16 +2772,12 @@ class ProjectQueryEngine:
         tca_scores: dict[str, float] = {}
         tca_used = False
         try:
-            import os
-            from pathlib import Path
-
             from token_savior.tca_engine import TCAEngine
+            from token_savior.telemetry import stats_dir as _stats_dir
 
-            stats_dir = Path(
-                os.path.expanduser(
-                    os.environ.get("TOKEN_SAVIOR_STATS_DIR", "~/.local/share/token-savior")
-                )
-            )
+            # Deja resolu a l'usage avant #90 ; passe par la reference unique
+            # pour que les six sites ne puissent plus diverger.
+            stats_dir = _stats_dir()
             if (stats_dir / "tca_coactivation.json").exists():
                 engine = TCAEngine(stats_dir)
                 co = engine.get_coactive_symbols(name, top_k=200, min_coactivation=1)

--- a/src/token_savior/server_handlers/tool_search.py
+++ b/src/token_savior/server_handlers/tool_search.py
@@ -36,6 +36,8 @@ import math
 import os
 from typing import Any
 
+from token_savior import telemetry
+
 # Cached at first call; module-level to survive across tool invocations.
 _TOOL_EMBED_CACHE: dict[str, list[float]] | None = None
 _TOOL_DESCRIPTIONS: dict[str, str] | None = None
@@ -46,10 +48,25 @@ _TOOL_DESCRIPTIONS: dict[str, str] | None = None
 # ts_search cold start measured on 2026-07-04 (the other half is the Nomic
 # model load, unavoidable in-process). Keyed by a hash of (names+descriptions+
 # model), so edited descriptions or a model swap invalidate it automatically.
-_STATS_DIR = os.path.expanduser(
-    os.environ.get("TOKEN_SAVIOR_STATS_DIR", "~/.local/share/token-savior")
+# Point de surcharge : `test_tool_embed_disk_cache` le rebinde par cas. Compare
+# a sa valeur d'import pour distinguer « personne n'a rien impose, redemande a
+# l'environnement » de « quelqu'un a impose un chemin, il gagne » -- meme forme
+# que `db_core.chemin_memoire()`. Fige a l'import, `TOKEN_SAVIOR_STATS_DIR` pose
+# apres ce premier import ne comptait plus ici alors qu'il comptait dans
+# `telemetry` : le meme processus ecrivait a deux endroits (#90).
+_EMBED_CACHE_INITIAL = os.path.join(
+    os.path.expanduser(
+        os.environ.get("TOKEN_SAVIOR_STATS_DIR", "~/.local/share/token-savior")
+    ),
+    "tool_embeddings.json",
 )
-_EMBED_CACHE_FILE = os.path.join(_STATS_DIR, "tool_embeddings.json")
+_EMBED_CACHE_FILE = _EMBED_CACHE_INITIAL
+
+
+def _embed_cache_file() -> str:
+    if _EMBED_CACHE_FILE != _EMBED_CACHE_INITIAL:
+        return _EMBED_CACHE_FILE
+    return str(telemetry.stats_dir() / "tool_embeddings.json")
 
 
 def _cache_signature(descs: dict[str, str]) -> str:
@@ -72,7 +89,7 @@ def _load_disk_embeds(sig: str) -> dict[str, list[float]] | None:
     """Return persisted embeddings iff the on-disk signature matches ``sig``."""
     import json
     try:
-        with open(_EMBED_CACHE_FILE, encoding="utf-8") as f:
+        with open(_embed_cache_file(), encoding="utf-8") as f:
             blob = json.load(f)
     except (OSError, ValueError):
         return None
@@ -88,11 +105,12 @@ def _save_disk_embeds(sig: str, embeds: dict[str, list[float]]) -> None:
     """Persist embeddings atomically (best-effort, never raises into dispatch)."""
     import json
     try:
-        os.makedirs(_STATS_DIR, exist_ok=True)
-        tmp = _EMBED_CACHE_FILE + ".tmp"
+        cible = _embed_cache_file()
+        os.makedirs(os.path.dirname(cible), exist_ok=True)
+        tmp = cible + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump({"signature": sig, "embeds": embeds}, f)
-        os.replace(tmp, _EMBED_CACHE_FILE)
+        os.replace(tmp, cible)
     except OSError:
         pass
 

--- a/src/token_savior/server_runtime.py
+++ b/src/token_savior/server_runtime.py
@@ -408,7 +408,7 @@ def _get_stats_file(project_root: str) -> str:
     """Return path to the stats JSON file for this project."""
     slug = hashlib.md5(project_root.encode()).hexdigest()[:8]
     name = os.path.basename(project_root.rstrip("/"))
-    return os.path.join(s._STATS_DIR, f"{name}-{slug}.json")
+    return os.path.join(s.stats_dir(), f"{name}-{slug}.json")
 
 
 def _load_cumulative_stats(stats_file: str) -> dict[str, Any]:
@@ -448,7 +448,7 @@ def _flush_stats(slot: _ProjectSlot, naive_chars: int) -> None:
     if not slot.stats_file:
         return
     try:
-        os.makedirs(s._STATS_DIR, exist_ok=True)
+        os.makedirs(s.stats_dir(), exist_ok=True)
         cum = _load_cumulative_stats(slot.stats_file)
         session_calls = sum(s._tool_call_counts.values()) - s._tool_call_counts.get(
             "get_stats", 0

--- a/src/token_savior/server_state.py
+++ b/src/token_savior/server_state.py
@@ -14,6 +14,7 @@ import uuid
 from collections import deque
 from pathlib import Path
 
+from token_savior import telemetry
 from token_savior.leiden_communities import LeidenCommunities
 from token_savior.linucb_injector import LinUCBInjector
 from token_savior.markov_prefetcher import PPMPrefetcher
@@ -42,6 +43,39 @@ def get_server():
     return _server_singleton
 
 
+# Moteurs d'optimisation, construits au premier acces et non a l'import.
+#
+# Les construire a l'import figeait le repertoire de statistiques avant que
+# quiconque ait pu le choisir -- et `TCAEngine.__init__` fait un
+# `mkdir(parents=True)`, donc importer ce module creait le repertoire fige sur
+# le disque (#90). Ils restent des attributs de module : `state._prefetcher`
+# marche comme avant, et un test qui fait `monkeypatch.setattr(server_state,
+# "_tca_engine", espion)` gagne toujours, puisque le `__getattr__` d'un module
+# n'est consulte que pour un nom absent.
+#
+# Declare avant `__getattr__` pour qu'un acces pendant l'import ne tombe jamais
+# sur un nom pas encore defini.
+_MOTEURS = {
+    # Markov prefetcher (P8) — PPM variable-order model on tool-call sequences.
+    "_prefetcher": PPMPrefetcher,
+    # TCA — Tenseur de Co-Activation (PMI on symbol co-activation).
+    "_tca_engine": TCAEngine,
+    # Leiden community detector — clusters the symbol dependency graph.
+    "_leiden": LeidenCommunities,
+    # LinUCB contextual bandit — ranks observations for injection.
+    "_linucb": LinUCBInjector,
+    # Cross-session warm start — finds historical sessions with similar signature.
+    "_warm_start": SessionWarmStart,
+}
+
+
+def _construire_moteur(nom: str):
+    """Construit un moteur au premier acces, puis le fige comme un vrai attribut."""
+    instance = _MOTEURS[nom](Path(stats_dir()))
+    globals()[nom] = instance
+    return instance
+
+
 # Backward-compat alias. Many call sites do `from token_savior.server_state
 # import server` then access `server.run(...)`. We expose `server` as a
 # property-like attribute via __getattr__ on the module so that the first
@@ -49,6 +83,8 @@ def get_server():
 def __getattr__(name):
     if name == "server":
         return get_server()
+    if name in _MOTEURS:
+        return _construire_moteur(name)
     raise AttributeError(f"module 'token_savior.server_state' has no attribute {name!r}")
 
 # ---------------------------------------------------------------------------
@@ -109,25 +145,21 @@ _SRC_CACHEABLE_TOOLS: frozenset[str] = frozenset({
 # Persistent stats configuration
 # ---------------------------------------------------------------------------
 
-_STATS_DIR: str = os.path.expanduser(
-    os.environ.get("TOKEN_SAVIOR_STATS_DIR", "~/.local/share/token-savior")
-)
+def stats_dir() -> str:
+    """Ou ce module ecrit, demande au moment ou il ecrit (#90).
+
+    `_STATS_DIR` etait une constante calculee a l'import, et les cinq moteurs
+    ci-dessous etaient construits avec elle, egalement a l'import. Poser
+    `TOKEN_SAVIOR_STATS_DIR` apres un `import token_savior.server_state` ne
+    changeait donc plus rien ici, alors que `telemetry` en tenait compte : le
+    meme processus ecrivait dans deux repertoires.
+    """
+    return str(telemetry.stats_dir())
+
+
 _MAX_SESSION_HISTORY: int = 200
 
-# ---------------------------------------------------------------------------
-# Optimization engines (instantiated once at module import)
-# ---------------------------------------------------------------------------
-
-# Markov prefetcher (P8) — PPM variable-order model on tool-call sequences.
-_prefetcher: PPMPrefetcher = PPMPrefetcher(Path(_STATS_DIR))
-# TCA — Tenseur de Co-Activation (PMI on symbol co-activation).
-_tca_engine: TCAEngine = TCAEngine(Path(_STATS_DIR))
-# Leiden community detector — clusters the symbol dependency graph.
-_leiden: LeidenCommunities = LeidenCommunities(Path(_STATS_DIR))
-# LinUCB contextual bandit — ranks observations for injection.
-_linucb: LinUCBInjector = LinUCBInjector(Path(_STATS_DIR))
-# Cross-session warm start — finds historical sessions with similar signature.
-_warm_start: SessionWarmStart = SessionWarmStart(Path(_STATS_DIR))
+# Les moteurs eux-memes sont declares plus haut, avec `__getattr__`.
 # Track symbols injected by memory_index so we can credit them as reward
 # when a subsequent call references them.
 _linucb_pending: dict[int, dict] = {}  # obs_id -> {features, context, injected_epoch}

--- a/src/token_savior/slot_manager.py
+++ b/src/token_savior/slot_manager.py
@@ -13,6 +13,7 @@ import sys
 import time
 from typing import TYPE_CHECKING
 
+from token_savior import telemetry
 from token_savior.cache_ops import CacheManager, compute_config_key
 from token_savior.git_tracker import get_changed_files, get_head_commit, is_git_repo
 from token_savior.project_indexer import ProjectIndexer, _rebuild_path_indexes
@@ -28,9 +29,14 @@ if TYPE_CHECKING:
 # Per-project slot dataclass
 # ---------------------------------------------------------------------------
 
-_STATS_DIR = os.path.expanduser(
-    os.environ.get("TOKEN_SAVIOR_STATS_DIR", "~/.local/share/token-savior")
-)
+def _stats_dir() -> str:
+    """Ou ce module ecrit, demande au moment ou il ecrit (#90).
+
+    `_STATS_DIR` etait fige a l'import, donc `TOKEN_SAVIOR_STATS_DIR` pose
+    apres ce premier import ne comptait plus ici alors qu'il comptait dans
+    `telemetry` : le meme processus ecrivait a deux endroits.
+    """
+    return str(telemetry.stats_dir())
 
 
 @dataclasses.dataclass
@@ -87,7 +93,7 @@ def _get_stats_file(project_root: str) -> str:
     """Return path to the stats JSON file for this project."""
     slug = hashlib.md5(project_root.encode()).hexdigest()[:8]
     name = os.path.basename(project_root.rstrip("/"))
-    return os.path.join(_STATS_DIR, f"{name}-{slug}.json")
+    return os.path.join(_stats_dir(), f"{name}-{slug}.json")
 
 
 # --- Registered-project persistence ---------------------------------------
@@ -98,14 +104,30 @@ def _get_stats_file(project_root: str) -> str:
 # collector-crypt-scanner reindexed 20x. Persisting the registry here lets
 # switch_project reach those projects across restarts (cache-aware, no rebuild).
 
-_REGISTERED_ROOTS_FILE = os.path.join(_STATS_DIR, "registered_projects.json")
+# Point de surcharge : `test_registered_persistence` le rebinde par cas. Compare
+# a sa valeur d'import pour distinguer « personne n'a rien impose, redemande a
+# l'environnement » de « quelqu'un a impose un chemin, il gagne » -- meme forme
+# que `db_core.chemin_memoire()`.
+_REGISTERED_ROOTS_INITIAL = os.path.join(
+    os.path.expanduser(
+        os.environ.get("TOKEN_SAVIOR_STATS_DIR", "~/.local/share/token-savior")
+    ),
+    "registered_projects.json",
+)
+_REGISTERED_ROOTS_FILE = _REGISTERED_ROOTS_INITIAL
+
+
+def _registered_roots_file() -> str:
+    if _REGISTERED_ROOTS_FILE != _REGISTERED_ROOTS_INITIAL:
+        return _REGISTERED_ROOTS_FILE
+    return os.path.join(_stats_dir(), "registered_projects.json")
 
 
 def _load_registered_roots() -> list[str]:
     """Return persisted project roots that still exist on disk (best-effort)."""
     import json
     try:
-        with open(_REGISTERED_ROOTS_FILE, encoding="utf-8") as f:
+        with open(_registered_roots_file(), encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, ValueError):
         return []
@@ -123,11 +145,12 @@ def _persist_registered_root(root: str) -> None:
         if root in existing:
             return
         existing.append(root)
-        os.makedirs(_STATS_DIR, exist_ok=True)
-        tmp = _REGISTERED_ROOTS_FILE + ".tmp"
+        cible = _registered_roots_file()
+        os.makedirs(os.path.dirname(cible), exist_ok=True)
+        tmp = cible + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(existing, f)
-        os.replace(tmp, _REGISTERED_ROOTS_FILE)
+        os.replace(tmp, cible)
     except OSError:
         pass
 

--- a/src/token_savior/telemetry.py
+++ b/src/token_savior/telemetry.py
@@ -45,13 +45,25 @@ from pathlib import Path
 _SCHEMA_VERSION = 1
 
 
-def _stats_dir() -> Path:
+def stats_dir() -> Path:
+    """Ou vivent les statistiques, demande au moment ou on ecrit.
+
+    Reference unique pour `TOKEN_SAVIOR_STATS_DIR`. La variable etait lue dans
+    six modules : quatre figeaient la reponse a l'import (`server_state`,
+    `dashboard`, `slot_manager`, `server_handlers/tool_search`), deux la
+    relisaient a l'usage. Un processus qui posait la variable apres l'import de
+    l'un des quatre ecrivait donc dans deux repertoires a la fois et relisait
+    dans celui des deux qu'il interrogeait (#90).
+
+    Ce module est une feuille -- il n'importe rien du paquet -- donc les cinq
+    autres peuvent s'y adresser sans cycle.
+    """
     raw = os.environ.get("TOKEN_SAVIOR_STATS_DIR", "~/.local/share/token-savior")
     return Path(os.path.expanduser(raw))
 
 
 def _counter_path() -> Path:
-    return _stats_dir() / "tool-calls.json"
+    return stats_dir() / "tool-calls.json"
 
 
 def _resolve_client() -> str:
@@ -226,7 +238,7 @@ def record_tool_call(tool_name: str) -> None:
 
 
 def _nudge_path() -> Path:
-    return _stats_dir() / "nudge-stats.json"
+    return stats_dir() / "nudge-stats.json"
 
 
 _nudge_lock = threading.Lock()

--- a/tests/test_registered_persistence.py
+++ b/tests/test_registered_persistence.py
@@ -16,7 +16,6 @@ from token_savior import slot_manager as sm
 
 def test_persist_and_load_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setattr(sm, "_REGISTERED_ROOTS_FILE", str(tmp_path / "reg.json"))
-    monkeypatch.setattr(sm, "_STATS_DIR", str(tmp_path))
     proj = tmp_path / "proj"
     proj.mkdir()
 
@@ -28,7 +27,6 @@ def test_persist_and_load_roundtrip(tmp_path, monkeypatch):
 
 def test_load_filters_missing_dirs(tmp_path, monkeypatch):
     monkeypatch.setattr(sm, "_REGISTERED_ROOTS_FILE", str(tmp_path / "reg.json"))
-    monkeypatch.setattr(sm, "_STATS_DIR", str(tmp_path))
     live = tmp_path / "live"
     live.mkdir()
     (tmp_path / "reg.json").write_text(
@@ -39,13 +37,11 @@ def test_load_filters_missing_dirs(tmp_path, monkeypatch):
 
 def test_load_missing_file_returns_empty(tmp_path, monkeypatch):
     monkeypatch.setattr(sm, "_REGISTERED_ROOTS_FILE", str(tmp_path / "absent.json"))
-    monkeypatch.setattr(sm, "_STATS_DIR", str(tmp_path))
     assert sm._load_registered_roots() == []
 
 
 def test_load_corrupt_file_returns_empty(tmp_path, monkeypatch):
     monkeypatch.setattr(sm, "_REGISTERED_ROOTS_FILE", str(tmp_path / "reg.json"))
-    monkeypatch.setattr(sm, "_STATS_DIR", str(tmp_path))
     (tmp_path / "reg.json").write_text("{not json", encoding="utf-8")
     assert sm._load_registered_roots() == []
 
@@ -56,7 +52,6 @@ def test_resolve_unregistered_by_path_and_basename(tmp_path, monkeypatch):
     from token_savior.server_handlers import project as proj
 
     monkeypatch.setattr(sm, "_REGISTERED_ROOTS_FILE", str(tmp_path / "reg.json"))
-    monkeypatch.setattr(sm, "_STATS_DIR", str(tmp_path))
     d = tmp_path / "myproj"
     d.mkdir()
 

--- a/tests/test_stats_dir_resolution.py
+++ b/tests/test_stats_dir_resolution.py
@@ -1,0 +1,137 @@
+"""`TOKEN_SAVIOR_STATS_DIR` must mean the same thing everywhere in one process.
+
+Six modules read it. Four froze the answer at import (`server_state`,
+`dashboard`, `slot_manager`, `server_handlers/tool_search`) and two resolved it
+at use (`telemetry`, `query_api`), so a process that sets the variable after
+any of the four are imported writes its statistics to two directories at once
+and reads them back from whichever half it asks. Reported as #90; same family
+as the data-directory defect fixed in #84.
+
+Not academic: `TCAEngine.__init__` calls `mkdir(parents=True)`, so importing
+`token_savior.server_state` creates the frozen directory on disk before anyone
+has had a chance to say where it should be.
+
+Run in a clean interpreter rather than by touching module state: `conftest`
+sets this variable at import time precisely so the suite's own modules agree,
+which is the workaround this test exists to make unnecessary. What is under
+test is the case where nobody arranged the import order, and only a fresh
+process has it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+# Every site the issue lists, probed through something that exists whether or
+# not the fix is in: the engines expose the directory they were built with,
+# and the path helpers can simply be asked for a path.
+_PROGRAMME = """
+import json, os
+from pathlib import Path
+
+from token_savior import server_state          # freezes the four, if they freeze
+from token_savior import dashboard, slot_manager, telemetry
+from token_savior.server_handlers import tool_search
+
+os.environ["TOKEN_SAVIOR_STATS_DIR"] = {cible!r}
+
+# tool_search: where does a save actually land? Asked of the filesystem rather
+# than of a module attribute, since the attribute is also the override hook.
+tool_search._save_disk_embeds("sig-sonde", {{"outil": [0.0]}})
+_candidats = [{cible!r}, os.path.expanduser("~/.local/share/token-savior")]
+_ou_tool_search = next(
+    (d for d in _candidats if os.path.exists(os.path.join(d, "tool_embeddings.json"))),
+    "nulle part",
+)
+
+# dashboard: plant a project payload in the new directory and see if it is read.
+Path({cible!r}).mkdir(parents=True, exist_ok=True)
+Path({cible!r}, "sonde-0000.json").write_text(json.dumps({{
+    "project": "/opt/projet-sonde", "total_calls": 1, "sessions": 1,
+    "total_chars_returned": 10, "total_naive_chars": 100,
+}}))
+lu_par_dashboard = [
+    r["project_root"] for r in dashboard.collect_dashboard_data()["projects"]
+]
+
+print(json.dumps({{
+    "prefetcher": str(server_state._prefetcher.stats_dir),
+    "tca": str(server_state._tca_engine.data_dir),
+    "leiden": str(server_state._leiden.stats_dir),
+    "linucb": str(server_state._linucb.stats_dir),
+    "warm_start": str(server_state._warm_start.stats_dir),
+    "slot_manager": os.path.dirname(slot_manager._get_stats_file("/opt/projet")),
+    "tool_search": _ou_tool_search,
+    "telemetry": os.path.dirname(str(telemetry._counter_path())),
+    "dashboard": lu_par_dashboard,
+}}))
+"""
+
+
+def _dans_un_interprete_neuf(programme: str, home) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("TOKEN_SAVIOR_STATS_DIR", None)
+    # Anything still frozen resolves to ~; keep that out of the real home.
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, "-c", programme],
+        capture_output=True, text=True, env=env, timeout=180, check=False,
+    )
+
+
+def test_stats_dir_set_after_import_is_honoured_everywhere(tmp_path) -> None:
+    cible = tmp_path / "ailleurs"
+    home = tmp_path / "home"
+    home.mkdir()
+    resultat = _dans_un_interprete_neuf(_PROGRAMME.format(cible=str(cible)), home)
+    assert resultat.returncode == 0, resultat.stderr
+    ou = json.loads(resultat.stdout.strip().splitlines()[-1])
+
+    desaccords = {
+        nom: chemin for nom, chemin in ou.items()
+        if nom != "dashboard" and chemin != str(cible)
+    }
+    assert not desaccords, (
+        f"ces sites ecrivent ailleurs que dans {cible} : {desaccords}"
+    )
+    assert "/opt/projet-sonde" in ou["dashboard"], (
+        f"le dashboard n'a pas lu {cible} : {ou['dashboard']}"
+    )
+    assert (cible / "tool_embeddings.json").exists(), "tool_search a ecrit ailleurs"
+
+
+def test_an_explicit_rebinding_still_wins(tmp_path) -> None:
+    """The per-test overrides the suite depends on must keep winning.
+
+    `test_registered_persistence` and `test_tool_embed_disk_cache` rebind
+    `_REGISTERED_ROOTS_FILE` and `_EMBED_CACHE_FILE` to a tmp path. Resolving
+    the environment at use time must not quietly take that away, or those tests
+    go back to writing into the user's real statistics directory.
+    """
+    impose = tmp_path / "impose"
+    impose.mkdir()
+    ignore = tmp_path / "ignore"
+    home = tmp_path / "home"
+    home.mkdir()
+    programme = (
+        "import os\n"
+        "from token_savior import slot_manager\n"
+        "from token_savior.server_handlers import tool_search\n"
+        f"os.environ['TOKEN_SAVIOR_STATS_DIR'] = {str(ignore)!r}\n"
+        f"slot_manager._REGISTERED_ROOTS_FILE = {str(impose / 'reg.json')!r}\n"
+        f"tool_search._EMBED_CACHE_FILE = {str(impose / 'embeds.json')!r}\n"
+        "slot_manager._persist_registered_root('/opt')\n"
+        "tool_search._save_disk_embeds('sig', {'outil': [0.0]})\n"
+    )
+    resultat = _dans_un_interprete_neuf(programme, home)
+    assert resultat.returncode == 0, resultat.stderr
+    assert (impose / "reg.json").exists(), resultat.stderr
+    assert (impose / "embeds.json").exists(), resultat.stderr
+    assert not (ignore / "registered_projects.json").exists(), (
+        "the environment overrode an override"
+    )
+    assert not (ignore / "tool_embeddings.json").exists(), (
+        "the environment overrode an override"
+    )

--- a/tests/test_tool_embed_disk_cache.py
+++ b/tests/test_tool_embed_disk_cache.py
@@ -19,7 +19,6 @@ def test_signature_stable_and_content_sensitive():
 
 def test_save_load_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setattr(tsx, "_EMBED_CACHE_FILE", str(tmp_path / "e.json"))
-    monkeypatch.setattr(tsx, "_STATS_DIR", str(tmp_path))
     descs = {"a": "a: foo", "b": "b: bar"}
     sig = tsx._cache_signature(descs)
     embeds = {"a": [0.1, 0.2, 0.3], "b": [0.4, 0.5, 0.6]}
@@ -30,7 +29,6 @@ def test_save_load_roundtrip(tmp_path, monkeypatch):
 
 def test_signature_mismatch_invalidates(tmp_path, monkeypatch):
     monkeypatch.setattr(tsx, "_EMBED_CACHE_FILE", str(tmp_path / "e.json"))
-    monkeypatch.setattr(tsx, "_STATS_DIR", str(tmp_path))
     tsx._save_disk_embeds("sig-old", {"a": [0.1]})
     assert tsx._load_disk_embeds("sig-new") is None
 


### PR DESCRIPTION
Closes #90.

`telemetry.stats_dir()` is now the single resolver, called at use by all six sites. It lives in `telemetry` because that module imports nothing from the package, so the other five reach it without a cycle — say the word if you would rather it had its own module.

## `server_state`, the one you said had a blast radius

It built five long-lived engines from the frozen path at module level. They are now built on first access, through the module `__getattr__` that already existed for `server`:

```python
_MOTEURS = {"_prefetcher": PPMPrefetcher, "_tca_engine": TCAEngine, ...}

def __getattr__(name):
    if name == "server":
        return get_server()
    if name in _MOTEURS:
        return _construire_moteur(name)
    raise AttributeError(...)
```

Nothing at the call sites changes. `state._prefetcher` still reads as an attribute, and `monkeypatch.setattr(server_state, "_tca_engine", spy)` still wins, because a module `__getattr__` is consulted only for a name that is *absent* — the moment a test sets one, the real attribute shadows it. `test_tca_flush_wiring` passes untouched.

That laziness also fixes something #90 counted as latent. `TCAEngine.__init__` calls `mkdir(parents=True)`, so importing `token_savior.server_state` created the frozen directory before anyone could say where it should be. With the variable unset, the import alone created `~/.local/share/token-savior` on this machine.

## The two names tests rebind

`slot_manager._REGISTERED_ROOTS_FILE` and `tool_search._EMBED_CACHE_FILE` stay module-level names, and follow the shape #84 used for the database path: compare against the import-time value, so an explicit override still wins and everything else re-asks the environment.

```python
_REGISTERED_ROOTS_INITIAL = os.path.join(<valeur a l'import>, "registered_projects.json")
_REGISTERED_ROOTS_FILE = _REGISTERED_ROOTS_INITIAL

def _registered_roots_file() -> str:
    if _REGISTERED_ROOTS_FILE != _REGISTERED_ROOTS_INITIAL:
        return _REGISTERED_ROOTS_FILE
    return os.path.join(_stats_dir(), "registered_projects.json")
```

`dashboard.DEFAULT_STATS_DIR` was frozen twice over — once as a constant, again as a default argument value evaluated at def time. Both functions now take `None` and resolve when they read.

## Verification

`tests/test_stats_dir_resolution.py`, in a clean interpreter — `conftest` sets the variable at import precisely to work around this defect, so only a fresh process can see it. It sets the variable *after* importing, then asks each site where it actually writes rather than what constant it holds. Red before:

```
{'prefetcher': '…/home/.local/share/token-savior',
 'tca': '…', 'leiden': '…', 'linucb': '…', 'warm_start': '…',
 'slot_manager': '…', 'tool_search': '…'}
```

Seven sites on the frozen path, `telemetry` alone following the variable. Green after: all eight agree, the dashboard reads a payload planted in the new directory, and the second test proves the two explicit rebindings still beat the environment.

2850 passed, 5 skipped. `ruff check src tests` clean.

## What this does NOT do

- **It does not touch the other environment variables.** #90 says a sweep of `src/` finds exactly one other variable with mixed read timing and this was it; I did not re-run that sweep, so that claim is still yours, not mine.
- **It changes two existing tests.** `test_registered_persistence` and `test_tool_embed_disk_cache` each rebound `_STATS_DIR` alongside the file path. The write path now derives its directory from the file path they already override, so the second patch had nothing left to do and is removed. No assertion changed.
- **`DEFAULT_STATS_DIR` is gone rather than deprecated.** It had three references, all inside `dashboard.py`. If you consider it public surface, it can come back as a call-time alias.
- **It does not make the engines cheap.** They are still built once and kept; only the moment moved. A process that sets the variable *between* two accesses to the same engine gets the first answer, which is the same guarantee a singleton has always given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
