### PR TITLE
feat(eval_rappel): --mode les-deux, the control beside the honest number

### DIFF
--- a/scripts/eval_rappel.py
+++ b/scripts/eval_rappel.py
@@ -142,8 +142,9 @@ def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--projet", required=True, help="project_root a mesurer")
     p.add_argument("--db", default=str(Path.home() / ".local/share/token-savior/memory.db"))
-    p.add_argument("--mode", choices=("contenu", "titre"), default="contenu",
-                   help="contenu = non biaise (defaut) ; titre = temoin flatteur")
+    p.add_argument("--mode", choices=("contenu", "titre", "les-deux"), default="contenu",
+                   help="contenu = non biaise (defaut) ; titre = temoin flatteur ; "
+                        "les-deux = les deux dans le meme run")
     p.add_argument("--n", type=int, default=45)
     p.add_argument("--limite", type=int, default=10)
     p.add_argument("--graine", type=int, default=11)
@@ -155,34 +156,53 @@ def main(argv: list[str] | None = None) -> int:
         print(f"base introuvable : {db}", file=sys.stderr)
         return 2
 
-    cas = construire_jeu(db, a.projet, a.n, a.mode, a.graine)
-    if not cas:
-        print(f"aucune observation exploitable pour {a.projet!r} dans {db}", file=sys.stderr)
-        return 2
-
-    mesure = mesurer(cas, a.projet, a.limite)
-    sortie = {
-        "projet": a.projet, "mode": a.mode, "cas": len(cas),
-        "limite": a.limite, "graine": a.graine, "mesure": mesure,
-    }
+    modes = ("contenu", "titre") if a.mode == "les-deux" else (a.mode,)
+    resultats: dict[str, dict] = {}
+    for mode in modes:
+        cas = construire_jeu(db, a.projet, a.n, mode, a.graine)
+        if not cas:
+            print(f"aucune observation exploitable pour {a.projet!r} dans {db} "
+                  f"(mode {mode})", file=sys.stderr)
+            return 2
+        resultats[mode] = {
+            "projet": a.projet, "mode": mode, "cas": len(cas),
+            "limite": a.limite, "graine": a.graine,
+            "mesure": mesurer(cas, a.projet, a.limite),
+        }
 
     if a.json:
-        print(json.dumps(sortie, ensure_ascii=False, indent=2))
+        # Un mode seul garde sa forme : `modes` n'apparait qu'en les-deux, pour
+        # ne pas casser ce qui lit deja la sortie a plat.
+        charge = ({"projet": a.projet, "limite": a.limite, "graine": a.graine,
+                   "modes": resultats}
+                  if a.mode == "les-deux" else resultats[a.mode])
+        print(json.dumps(charge, ensure_ascii=False, indent=2))
         return 0
 
     print(f"  projet : {a.projet}")
-    print(f"  mode   : {a.mode}" + ("  (BIAISE, temoin seulement)" if a.mode == "titre" else ""))
-    print(f"  cas    : {len(cas)} observations, fenetre {a.limite}\n")
-    for forme in ("courte", "longue"):
-        d = mesure[forme]
-        rang = f"{d['rang_moyen']:.2f}" if d["rang_moyen"] else "-"
-        print(f"    requete {forme:7} : {d['trouve']:3}/{d['sur']} ({d['taux']:5.1f} %)"
-              f"   rang moyen {rang}")
-    ecart = (mesure["courte"]["taux"] - mesure["longue"]["taux"])
-    if ecart > 5:
-        print(f"\n  ECART de {ecart:.1f} points entre mots-cles et question humaine.")
-        print("  C'est le symptome a surveiller : le moteur repond aux mots-cles")
-        print("  et pas aux questions.")
+    for mode, bloc in resultats.items():
+        mesure = bloc["mesure"]
+        print(f"  mode   : {mode}"
+              + ("  (BIAISE, temoin seulement)" if mode == "titre" else ""))
+        print(f"  cas    : {bloc['cas']} observations, fenetre {a.limite}\n")
+        for forme in ("courte", "longue"):
+            d = mesure[forme]
+            rang = f"{d['rang_moyen']:.2f}" if d["rang_moyen"] else "-"
+            print(f"    requete {forme:7} : {d['trouve']:3}/{d['sur']} ({d['taux']:5.1f} %)"
+                  f"   rang moyen {rang}")
+        ecart = (mesure["courte"]["taux"] - mesure["longue"]["taux"])
+        if ecart > 5:
+            print(f"\n  ECART de {ecart:.1f} points entre mots-cles et question humaine.")
+            print("  C'est le symptome a surveiller : le moteur repond aux mots-cles")
+            print("  et pas aux questions.")
+        print()
+
+    if a.mode == "les-deux":
+        honnete = resultats["contenu"]["mesure"]["courte"]["taux"]
+        temoin = resultats["titre"]["mesure"]["courte"]["taux"]
+        print(f"  Ecart temoin - honnete : {temoin - honnete:+.1f} points.")
+        print("  C'est ce que vaudrait la mesure si les requetes etaient baties")
+        print("  sur le titre de leur propre cible. A lire, jamais a citer.")
     return 0
 
 

--- a/tests/test_eval_rappel.py
+++ b/tests/test_eval_rappel.py
@@ -1,0 +1,91 @@
+"""`--mode les-deux` : le temoin biaise a cote de la mesure honnete, en un run.
+
+Le script sait deja construire les deux jeux de requetes, mais un seul par
+execution. Le biais du mode `titre` ne se voit pourtant que par comparaison :
+seul, un 100 % flatteur ressemble a un bon resultat. Deux commandes a lancer,
+c'est bon marche ; ce n'est pas automatique, et c'est la difference qui a coute
+une decision le 27/07/2026 -- une amelioration mesuree sur un corpus derive des
+titres, jugee trop belle, ecartee au profit d'une variante qui ne changeait
+rien.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from token_savior import memory_db
+
+PROJET = "/opt/projet-eval"
+RACINE = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def script():
+    spec = importlib.util.spec_from_file_location(
+        "eval_rappel", RACINE / "scripts" / "eval_rappel.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def base(tmp_path, monkeypatch):
+    from token_savior import db_core
+    from token_savior import memory_db as md
+
+    cible = tmp_path / "memoire.db"
+    monkeypatch.setattr(db_core, "MEMORY_DB_PATH", cible)
+    monkeypatch.setattr(md, "MEMORY_DB_PATH", cible)
+    # `construire_jeu` exige titre > 20 et contenu > 80 caracteres, et au moins
+    # cinq jetons utilisables -- dans le titre pour le mode `titre`, dans le
+    # contenu et absents du titre pour le mode `contenu`.
+    for i in range(12):
+        memory_db.observation_save(
+            None, PROJET, "convention",
+            f"Convention numero {i} regissant nommage horodatage condensat "
+            f"artefacts publies",
+            f"Chaque livrable du lot {i} embarque une empreinte tronquee plutot "
+            f"qu'un compteur incremental, lequel ne survit jamais a deux "
+            f"machines emettant simultanement vers le meme entrepot. Cas {i}.",
+        )
+    return cible
+
+
+def test_les_deux_modes_sortent_du_meme_run(script, base, capsys) -> None:
+    """Sans comparaison, un temoin biaise se lit comme un bon resultat."""
+    code = script.main([
+        "--projet", PROJET, "--db", str(base), "--mode", "les-deux", "--n", "5",
+    ])
+    assert code == 0
+    sortie = capsys.readouterr().out
+    assert "contenu" in sortie and "titre" in sortie, sortie
+    assert "BIAISE" in sortie, "le temoin doit rester etiquete comme tel"
+
+
+def test_les_deux_en_json_porte_les_deux_mesures(script, base, capsys) -> None:
+    code = script.main([
+        "--projet", PROJET, "--db", str(base), "--mode", "les-deux", "--n", "5",
+        "--json",
+    ])
+    assert code == 0
+    charge = json.loads(capsys.readouterr().out)
+    assert set(charge["modes"]) == {"contenu", "titre"}, charge
+    for mode, bloc in charge["modes"].items():
+        assert bloc["mode"] == mode
+        assert "mesure" in bloc
+
+
+def test_un_mode_seul_garde_sa_forme_de_sortie(script, base, capsys) -> None:
+    """Le contrat existant ne bouge pas : `modes` n'apparait qu'en les-deux."""
+    code = script.main([
+        "--projet", PROJET, "--db", str(base), "--mode", "contenu", "--n", "5",
+        "--json",
+    ])
+    assert code == 0
+    charge = json.loads(capsys.readouterr().out)
+    assert charge["mode"] == "contenu"
+    assert "modes" not in charge


### PR DESCRIPTION
The second thing you flagged on #92: cheap and automatic are not the same thing.

`--mode les-deux` builds both query sets in one run, prints them one after the other, and then the gap between the two short-query rates. The default stays `contenu`, and a single-mode `--json` payload keeps its exact shape — the `modes` key appears only for `les-deux` — so nothing reading the current output has to change. Flipping the default is a one-word edit if you want it, but that changes the JSON contract for anyone already parsing it, which is your call rather than mine.

Run here, on 126 observations pulled from months of notes on an unrelated project:

```
  mode   : contenu
    requete courte  :  45/45 (100.0 %)   rang moyen 1.00
    requete longue  :  45/45 (100.0 %)   rang moyen 1.00

  mode   : titre  (BIAISE, temoin seulement)
    requete courte  :   9/9 (100.0 %)   rang moyen 1.11
    requete longue  :   9/9 (100.0 %)   rang moyen 1.00

  Ecart temoin - honnete : +0.0 points.
```

The gap is +0.0 because both modes are saturated. That is the useful reading and it is the reason the summary line prints even when it is boring: this corpus cannot discriminate between the two, so neither number is evidence of anything. Two separate runs would have shown the same thing and left it to whoever compared them to notice.

The script had no tests. Three added: both modes come out of one run with the control still labelled BIAISE, the JSON carries both measurements, and a single mode keeps its existing flat payload. Red before on the first two (`invalid choice: 'les-deux'`), green after, third one green throughout as the contract guard.

2867 passed, 5 skipped. `ruff check src/ tests/` clean — `scripts/eval_rappel.py` trips `EXE001` (shebang, file not executable) both before and after this change, and CI does not lint `scripts/`, so I left it alone.

## What this does not do

- **It does not vary anything but the query register.** Corpus, window and seed are still one run's worth. The register was the axis you named; the others are still one-at-a-time.
- **It does not make the control safe to quote.** It makes it hard to read alone. Those are different, and the label stays.
- **The measurement in #92 is separate** — I posted the threshold sweep in this environment there rather than folding it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
