### PR TITLE
fix(tool_capture): no bogus preview for large outputs with few lines

### DIFF
--- a/src/token_savior/memory/tool_capture.py
+++ b/src/token_savior/memory/tool_capture.py
@@ -77,14 +77,15 @@ def _make_preview(output: str) -> str:
         return output
     lines = output.splitlines()
     if len(lines) <= _DEFAULT_PREVIEW_LINES * 2:
-        head = "\n".join(lines[:_DEFAULT_PREVIEW_LINES])
-        tail = "\n".join(lines[-_DEFAULT_PREVIEW_LINES:])
+        # Few long lines: a head/tail split would duplicate the middle and
+        # render a negative omitted count. Byte-cap the whole text instead.
+        preview = output
     else:
         head = "\n".join(lines[:_DEFAULT_PREVIEW_LINES])
         tail = "\n".join(lines[-_DEFAULT_PREVIEW_LINES:])
-    omitted = len(lines) - 2 * _DEFAULT_PREVIEW_LINES
-    sep = f"\n... [{omitted} lines omitted, full output stored — use capture_get] ...\n"
-    preview = head + sep + tail
+        omitted = len(lines) - 2 * _DEFAULT_PREVIEW_LINES
+        sep = f"\n... [{omitted} lines omitted, full output stored — use capture_get] ...\n"
+        preview = head + sep + tail
     if len(preview) > _DEFAULT_PREVIEW_BYTES:
         preview = preview[: _DEFAULT_PREVIEW_BYTES] + "…"
     return preview

--- a/tests/test_tool_capture.py
+++ b/tests/test_tool_capture.py
@@ -269,3 +269,21 @@ def test_migration_adds_output_hash_to_predating_db(monkeypatch, tmp_path):
         "SELECT output_hash FROM tool_captures WHERE id = ?", (res["id"],)).fetchone()[0]
     conn.close()
     assert h
+
+
+def test_preview_short_line_large_output_no_negative_omitted():
+    """> preview byte cap but <= 2x preview lines: no bogus 'omitted' marker (#95)."""
+    output = "\n".join(("y" * 70 + f" L{i}") for i in range(12))  # ~889 B, 12 lines
+    preview = tool_capture._make_preview(output)
+    assert "omitted" not in preview
+    # No line may appear twice (head/tail overlap bug).
+    lines = [ln for ln in preview.splitlines() if ln.startswith("y")]
+    assert len(lines) == len(set(lines))
+
+
+def test_preview_omitted_count_positive_when_marker_shown():
+    """The separator only ever renders a positive omitted count (#95)."""
+    output = "\n".join(f"row-{i:04d} " + "z" * 60 for i in range(40))
+    preview = tool_capture._make_preview(output)
+    assert "[-" not in preview
+    assert "[24 lines omitted" in preview  # 40 - 2*8


### PR DESCRIPTION
Fixes #95.

For outputs above the preview byte cap (800 B) but at or below 2× `_DEFAULT_PREVIEW_LINES` lines, `_make_preview` built overlapping `lines[:8]` / `lines[-8:]` slices: middle lines rendered twice and the separator showed a negative count (`... [-4 lines omitted ...]`). The `if len(lines) <= _DEFAULT_PREVIEW_LINES * 2` / `else` had byte-identical branches — the intended short-circuit was dead code.

**Fix:** for such outputs, byte-cap the whole text (no separator, no duplication). The head/tail split — and its omitted marker — now only renders when the count is positive.

**Tests:** `test_preview_short_line_large_output_no_negative_omitted` reproduces the bug and failed against the previous code (`AssertionError: 'omitted' not in preview`); `test_preview_omitted_count_positive_when_marker_shown` pins the positive-count invariant for the long-output path. Full capture suite: 55 passed.
