### PR TITLE
feat(tool_capture): dedup identical captures and purge beyond a TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ values shown as *bool* accept `1`/`true`/`yes` (and `on` where noted).
 |---|---|---|
 | `TS_CAPTURE_THRESHOLD_BYTES` | `4096` | Minimum tool-output size to sandbox |
 | `TS_CAPTURE_REPLACE=1` | off | Strong-replace: tell the agent to ignore the inline output and `capture_get` the URI |
+| `TS_CAPTURE_TTL_DAYS` | `30` | Captures older than this are purged on the next `capture_put`; `0` disables the GC |
 | `TS_BASH_COMPACT=1` | off | Enable PostToolUse Bash output compactors |
 | `TS_COMPACT_INLINE_THRESHOLD` | `4096` | Hybrid mode: compact-result size above which the full original is also sandboxed |
 | `TS_COMPACT_TINY_THRESHOLD` | `256` | Hybrid mode: compact-result size below which the sandbox is always skipped |

--- a/src/token_savior/db_core.py
+++ b/src/token_savior/db_core.py
@@ -205,6 +205,10 @@ def run_migrations(db_path: Path | str | None = None) -> None:
 
     try:
         _ajouter_colonne(conn, "user_prompts", "project_root", "TEXT")
+        # Before the schema script, like user_prompts above: the script
+        # creates idx_tool_captures_hash, which needs the column to exist
+        # on databases that predate it.
+        _ajouter_colonne(conn, "tool_captures", "output_hash", "TEXT")
 
         schema_sql = _SCHEMA_PATH.read_text(encoding="utf-8")
         conn.executescript(schema_sql)

--- a/src/token_savior/memory/tool_capture.py
+++ b/src/token_savior/memory/tool_capture.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import sqlite3
 import sys
@@ -24,6 +25,35 @@ from token_savior import db_core
 _DEFAULT_PREVIEW_BYTES = 800
 _DEFAULT_PREVIEW_LINES = 8
 _MAX_OUTPUT_BYTES = 8 * 1024 * 1024  # 8 MiB hard cap; truncate beyond
+_DEDUP_WINDOW_S = 120  # identical put within this window returns the same row
+_DEFAULT_TTL_DAYS = 30  # rows older than this are purged on the next put
+
+
+def _ttl_seconds() -> int | None:
+    """TTL from TS_CAPTURE_TTL_DAYS (default 30 days); 0 or invalid disables."""
+    raw = os.environ.get("TS_CAPTURE_TTL_DAYS", str(_DEFAULT_TTL_DAYS))
+    try:
+        days = int(raw)
+    except ValueError:
+        days = _DEFAULT_TTL_DAYS
+    if days <= 0:
+        return None
+    return days * 86400
+
+
+def _purge_expired(conn: sqlite3.Connection, now: int) -> int:
+    """Delete captures older than the TTL. Cheap when there is nothing to do:
+    one MIN() probe on the created_at index before any DELETE."""
+    ttl = _ttl_seconds()
+    if ttl is None:
+        return 0
+    cutoff = now - ttl
+    oldest = conn.execute("SELECT MIN(created_at_epoch) FROM tool_captures").fetchone()[0]
+    if oldest is None or oldest >= cutoff:
+        return 0
+    return conn.execute(
+        "DELETE FROM tool_captures WHERE created_at_epoch < ?", (cutoff,)
+    ).rowcount
 
 
 def _hash_args(args: Any) -> str:
@@ -79,23 +109,46 @@ def capture_put(
         output = output[:_MAX_OUTPUT_BYTES] + "\n…[truncated to 8MiB cap]"
     preview = _make_preview(output)
     args_hash = _hash_args({"tool": tool_name, "args": args_summary})
+    output_hash = hashlib.sha256(output.encode("utf-8", errors="replace")).hexdigest()[:32]
     epoch = int(time.time())
     n_lines = output.count("\n") + (0 if output.endswith("\n") or not output else 1)
     try:
         conn = db_core.get_db()
+        # Dedup: an identical output for the same tool/args/session within the
+        # window (e.g. the hook registered in two settings scopes firing twice)
+        # returns the existing handle instead of storing the bytes again.
+        row = conn.execute(
+            "SELECT id FROM tool_captures "
+            "WHERE output_hash = ? AND args_hash = ? "
+            "  AND ifnull(session_id, '') = ifnull(?, '') "
+            "  AND created_at_epoch >= ? "
+            "ORDER BY id DESC LIMIT 1",
+            (output_hash, args_hash, session_id, epoch - _DEDUP_WINDOW_S),
+        ).fetchone()
+        if row:
+            conn.close()
+            return {
+                "id": row["id"],
+                "uri": f"ts://capture/{row['id']}",
+                "preview": preview,
+                "bytes": len(output),
+                "lines": n_lines,
+                "deduped": True,
+            }
         cur = conn.execute(
             "INSERT INTO tool_captures "
             "(session_id, project_root, tool_name, args_hash, args_summary, "
-            " output_full, output_preview, output_bytes, output_lines, "
+            " output_full, output_hash, output_preview, output_bytes, output_lines, "
             " created_at_epoch, meta_json) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 session_id, project_root, tool_name, args_hash, args_summary,
-                output, preview, len(output), n_lines, epoch,
+                output, output_hash, preview, len(output), n_lines, epoch,
                 json.dumps(meta) if meta else None,
             ),
         )
         cap_id = cur.lastrowid
+        _purge_expired(conn, epoch)
         conn.commit()
         conn.close()
     except sqlite3.Error as exc:

--- a/src/token_savior/memory_schema.sql
+++ b/src/token_savior/memory_schema.sql
@@ -326,6 +326,7 @@ CREATE TABLE IF NOT EXISTS tool_captures (
     args_hash         TEXT,
     args_summary      TEXT,
     output_full       TEXT NOT NULL,
+    output_hash       TEXT,
     output_preview    TEXT,
     output_bytes      INTEGER NOT NULL,
     output_lines      INTEGER NOT NULL DEFAULT 0,
@@ -334,6 +335,7 @@ CREATE TABLE IF NOT EXISTS tool_captures (
 );
 
 CREATE INDEX IF NOT EXISTS idx_tool_captures_session ON tool_captures(session_id);
+CREATE INDEX IF NOT EXISTS idx_tool_captures_hash    ON tool_captures(output_hash);
 CREATE INDEX IF NOT EXISTS idx_tool_captures_created ON tool_captures(created_at_epoch DESC);
 CREATE INDEX IF NOT EXISTS idx_tool_captures_tool    ON tool_captures(tool_name);
 CREATE INDEX IF NOT EXISTS idx_tool_captures_project ON tool_captures(project_root);

--- a/tests/test_tool_capture.py
+++ b/tests/test_tool_capture.py
@@ -186,3 +186,86 @@ def test_meta_persists_as_json():
     )
     got = tool_capture.capture_get(res["id"])
     assert "exit_code" in (got["meta_json"] or "")
+
+
+def test_put_dedups_identical_output_within_window():
+    """Same output + args + session shortly after: same id, one row (#96)."""
+    out = "identical payload\n" * 50
+    first = tool_capture.capture_put(
+        tool_name="Bash", output=out, args_summary="ls", session_id="s1")
+    second = tool_capture.capture_put(
+        tool_name="Bash", output=out, args_summary="ls", session_id="s1")
+    assert second["id"] == first["id"]
+    assert second.get("deduped") is True
+    conn = db_core.get_db()
+    n = conn.execute("SELECT COUNT(*) FROM tool_captures").fetchone()[0]
+    conn.close()
+    assert n == 1
+
+
+def test_put_no_dedup_across_sessions_or_content():
+    out = "payload\n" * 50
+    a = tool_capture.capture_put(tool_name="Bash", output=out, session_id="s1")
+    b = tool_capture.capture_put(tool_name="Bash", output=out, session_id="s2")
+    c = tool_capture.capture_put(tool_name="Bash", output=out + "x", session_id="s1")
+    assert len({a["id"], b["id"], c["id"]}) == 3
+
+
+def test_put_purges_rows_older_than_ttl(monkeypatch):
+    """capture_put garbage-collects rows beyond TS_CAPTURE_TTL_DAYS (#96)."""
+    monkeypatch.setenv("TS_CAPTURE_TTL_DAYS", "7")
+    old = tool_capture.capture_put(tool_name="Bash", output="ancient", session_id="s1")
+    conn = db_core.get_db()
+    conn.execute(
+        "UPDATE tool_captures SET created_at_epoch = created_at_epoch - 8 * 86400 "
+        "WHERE id = ?", (old["id"],))
+    conn.commit()
+    conn.close()
+    tool_capture.capture_put(tool_name="Bash", output="fresh", session_id="s1")
+    conn = db_core.get_db()
+    ids = [r[0] for r in conn.execute("SELECT id FROM tool_captures").fetchall()]
+    conn.close()
+    assert old["id"] not in ids
+
+
+def test_put_ttl_zero_disables_purge(monkeypatch):
+    monkeypatch.setenv("TS_CAPTURE_TTL_DAYS", "0")
+    old = tool_capture.capture_put(tool_name="Bash", output="ancient", session_id="s1")
+    conn = db_core.get_db()
+    conn.execute(
+        "UPDATE tool_captures SET created_at_epoch = created_at_epoch - 400 * 86400 "
+        "WHERE id = ?", (old["id"],))
+    conn.commit()
+    conn.close()
+    tool_capture.capture_put(tool_name="Bash", output="fresh", session_id="s1")
+    conn = db_core.get_db()
+    n = conn.execute("SELECT COUNT(*) FROM tool_captures").fetchone()[0]
+    conn.close()
+    assert n == 2
+
+
+def test_migration_adds_output_hash_to_predating_db(monkeypatch, tmp_path):
+    """A database created before output_hash existed gains the column (#96)."""
+    import sqlite3 as _sq
+
+    db_path = tmp_path / "old.sqlite"
+    conn = _sq.connect(db_path)
+    conn.execute(
+        "CREATE TABLE tool_captures ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT,"
+        " project_root TEXT, tool_name TEXT NOT NULL, args_hash TEXT,"
+        " args_summary TEXT, output_full TEXT NOT NULL, output_preview TEXT,"
+        " output_bytes INTEGER NOT NULL, output_lines INTEGER NOT NULL DEFAULT 0,"
+        " created_at_epoch INTEGER NOT NULL, meta_json TEXT)")
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(db_core, "MEMORY_DB_PATH", db_path)
+    db_core._migrated_paths.clear()
+    db_core.run_migrations(db_path)
+    res = tool_capture.capture_put(tool_name="Bash", output="migrated ok")
+    assert res["id"] is not None
+    conn = db_core.get_db()
+    h = conn.execute(
+        "SELECT output_hash FROM tool_captures WHERE id = ?", (res["id"],)).fetchone()[0]
+    conn.close()
+    assert h


### PR DESCRIPTION
Fixes #96.

Two independent gaps closed in `capture_put`:

**Dedup.** New `output_hash` column (sha256-based, indexed). An identical output for the same tool/args/session within a 120 s window returns the existing handle (`deduped: true`) instead of inserting — a hook registered in two settings scopes (see #99) now costs one row instead of two. Different sessions or different bytes still insert normally.

**Retention.** After each insert, rows older than `TS_CAPTURE_TTL_DAYS` (default 30, `0` disables) are deleted. The GC is gated by a single `MIN(created_at_epoch)` probe on the existing index, so the common no-op case costs one indexed lookup. Every write goes through `capture_put`, so put-time GC bounds growth without needing a server-start hook; the FTS delete trigger keeps `tool_captures_fts` in sync.

**Migration.** `_ajouter_colonne(conn, "tool_captures", "output_hash", "TEXT")` runs *before* the schema script (same pattern and reason as `user_prompts.project_root`): the script now creates `idx_tool_captures_hash`, which needs the column to exist on databases that predate it. Covered by `test_migration_adds_output_hash_to_predating_db`, which builds the old-shape table by hand and migrates it.

**Tests** (red → green against the previous code):
- `test_put_dedups_identical_output_within_window` — failed before (two rows, two ids)
- `test_put_purges_rows_older_than_ttl` — failed before (old row survived)
- `test_put_no_dedup_across_sessions_or_content`, `test_put_ttl_zero_disables_purge` — pin the non-dedup/off paths
- full suite: 2872 passed, 5 skipped

README gains the `TS_CAPTURE_TTL_DAYS` row in the hooks env table.

Field numbers behind the default: 36 083 captures / 512 MiB / 14 253 exact duplicates in 18 days on one workstation.
