### PR TITLE
fix: resolve #97 #98 #99 #100 (git-diff rewrite, socket, ts-init dedup, stderr capture)

### DIFF
--- a/hooks/tool_capture_hook.py
+++ b/hooks/tool_capture_hook.py
@@ -98,9 +98,18 @@ def main() -> None:
         response = {"content": response}
     # Claude Code PostToolUse exposes the textual response under .content
     # for native tools, .stdout/.stderr for Bash, or as a string fallback.
+    stdout = response.get("stdout")
+    stdout = stdout if isinstance(stdout, str) else ""
+    stderr = response.get("stderr")
+    stderr = stderr if isinstance(stderr, str) else ""
+    # stderr must count toward the capture threshold too: a Bash command that
+    # writes only to stderr (test runners, linters, anything logging there)
+    # otherwise yields empty content, falls under THRESHOLD, and is never
+    # captured — while the compact path below already reads stderr (#100). The
+    # streams stay split for _compact(), so stderr is not double-counted there.
     content = (
         response.get("content")
-        or response.get("stdout")
+        or (stdout + ("\n" + stderr if stderr else ""))
         or response.get("output")
         or ""
     )
@@ -123,9 +132,9 @@ def main() -> None:
             from token_savior.compactors import compact as _compact
             tool_input = event.get("tool_input") or {}
             command = (tool_input.get("command") or "") if isinstance(tool_input, dict) else ""
-            stderr = response.get("stderr") if isinstance(response, dict) else ""
-            stderr = stderr if isinstance(stderr, str) else ""
-            result = _compact(command, content, stderr)
+            # stderr already normalized above; pass stdout (not the merged
+            # content) so the compactor still sees the two streams split.
+            result = _compact(command, stdout, stderr)
         except Exception as exc:
             sys.stderr.write(f"[ts-capture-hook] compact failed: {exc}\n")
             result = None

--- a/src/token_savior/bash_rewriter/rules.py
+++ b/src/token_savior/bash_rewriter/rules.py
@@ -125,12 +125,15 @@ def _match_git_diff(toks: list[str]) -> bool:
 
 def _apply_git_diff(cmd: str, toks: list[str]) -> str:
     rest = toks[2:]
+    # Only add --no-color. Unlike every other rule, --stat would change WHAT the
+    # command produces (a diffstat, not the patch): the hunks the agent asked
+    # for would never exist for the PostToolUse layer to recover or sandbox
+    # (#97). Output-side compaction is the GitDiffCompactor's job — it sees the
+    # real patch and, in hybrid mode, keeps the full diff retrievable.
     if rest:
-        # Has positional args (refs/paths) but no flags — still safe to
-        # append ``--no-color`` and ``--stat=200,5``.
         tail = " ".join(shlex.quote(t) for t in rest)
-        return f"git diff --no-color --stat=200,5 {tail}"
-    return "git diff --no-color --stat=200,5"
+        return f"git diff --no-color {tail}"
+    return "git diff --no-color"
 
 
 _GIT_LOG_N = re.compile(r"^(?:-n|--max-count=?)(\d+)?$")

--- a/src/token_savior/cli.py
+++ b/src/token_savior/cli.py
@@ -47,7 +47,23 @@ _HERE = Path(__file__).resolve().parent
 _TS_ROOT = _HERE.parent
 _CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))) / "ts"
 _ACTIVE_FILE = _CONFIG_DIR / "active"
-_SOCK_PATH = os.environ.get("TS_SOCK", "/tmp/ts.sock")
+
+
+def _default_sock_path() -> str:
+    """Socket path outside world-writable /tmp (#98).
+
+    A fixed /tmp/ts.sock lets another local user squat the name (the client
+    then talks to an attacker-controlled socket) and makes the stale-socket
+    remove raise PermissionError on sticky-bit /tmp. Prefer the per-user 0700
+    $XDG_RUNTIME_DIR; fall back to the CLI's own config dir.
+    """
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime:
+        return os.path.join(runtime, "ts.sock")
+    return str(_CONFIG_DIR / "ts.sock")
+
+
+_SOCK_PATH = os.environ.get("TS_SOCK") or _default_sock_path()
 _PID_FILE = _CONFIG_DIR / "daemon.pid"
 
 # Defaults reduce noise
@@ -148,7 +164,10 @@ def _daemon_start() -> str:
         return "daemon already running"
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     if os.path.exists(_SOCK_PATH):
-        os.remove(_SOCK_PATH)
+        try:
+            os.remove(_SOCK_PATH)
+        except OSError as exc:
+            return f"cannot remove stale socket {_SOCK_PATH}: {exc}"
     log = _CONFIG_DIR / "daemon.log"
     # spawn detached daemon. env propage WORKSPACE_ROOTS si actif.
     env = os.environ.copy()
@@ -239,9 +258,21 @@ def _daemon_serve() -> None:
     calls = 0
 
     if os.path.exists(_SOCK_PATH):
-        os.remove(_SOCK_PATH)
+        try:
+            os.remove(_SOCK_PATH)
+        except OSError as exc:
+            print(f"[ts-daemon] cannot remove stale socket {_SOCK_PATH}: {exc}",
+                  file=sys.stderr, flush=True)
+            raise SystemExit(1) from exc
+    Path(_SOCK_PATH).parent.mkdir(parents=True, exist_ok=True)
     srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    srv.bind(_SOCK_PATH)
+    # Bind under a restrictive umask so the socket is never observable with
+    # umask-derived permissions in the window between bind and chmod (#98).
+    _old_umask = os.umask(0o177)
+    try:
+        srv.bind(_SOCK_PATH)
+    finally:
+        os.umask(_old_umask)
     os.chmod(_SOCK_PATH, 0o600)
     srv.listen(8)
 

--- a/src/token_savior/cli_init/__init__.py
+++ b/src/token_savior/cli_init/__init__.py
@@ -20,7 +20,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from .agent_paths import SUPPORTED_AGENTS, detection_path, hook_config_paths, settings_path
-from .merger import added_entries, format_diff, merge_hook_config
+from .merger import _entry_fingerprint, added_entries, format_diff, merge_hook_config
 
 # Resolve the directory whose ``hooks/`` subdir holds the bundled configs.
 # Two layouts to support:
@@ -170,6 +170,63 @@ def _apply_bundles(existing: dict, bundles: Iterable[dict]) -> dict:
     return merged
 
 
+def _hook_name(cmd: str) -> str:
+    """Cross-install identity of a hook command: its module or script basename.
+    The full path differs per machine (venv, checkout), the hook name does not.
+    """
+    m = re.search(r"token_savior\.hooks\.(\w+)", cmd)
+    if m:
+        return m.group(1)
+    m = re.search(r"([\w-]+)\.py(?:\b|$)", cmd)
+    if m:
+        return m.group(1)
+    return cmd.strip()
+
+
+def _scope_hook_identities(path: Path | None) -> set[tuple[str, str]]:
+    """(matcher, hook-name) for every hook entry already in a settings file."""
+    out: set[tuple[str, str]] = set()
+    if path is None:
+        return out
+    try:
+        data = _read_settings(path)
+    except RuntimeError:
+        return out
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return out
+    for entries in hooks.values():
+        if not isinstance(entries, list):
+            continue
+        for e in entries:
+            if not isinstance(e, dict):
+                continue
+            matcher, cmd = _entry_fingerprint(e)
+            if cmd:
+                out.add((matcher, _hook_name(cmd)))
+    return out
+
+
+def _strip_cross_scope(after: dict, added: list, sibling_ids: set[tuple[str, str]]):
+    """Drop from `after` the newly-added entries whose (matcher, hook-name)
+    already exists in a sibling scope. Returns (kept, skipped) added-lists.
+    """
+    kept: list = []
+    skipped: list = []
+    for event, fp in added:
+        if (fp[0], _hook_name(fp[1])) in sibling_ids:
+            skipped.append((event, fp))
+            entries = after.get("hooks", {}).get(event)
+            if isinstance(entries, list):
+                after["hooks"][event] = [
+                    e for e in entries
+                    if not (isinstance(e, dict) and _entry_fingerprint(e) == fp)
+                ]
+        else:
+            kept.append((event, fp))
+    return kept, skipped
+
+
 # --------------------------------------------------------------------------- #
 # Public entrypoint                                                           #
 # --------------------------------------------------------------------------- #
@@ -192,6 +249,9 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Skip the confirmation prompt.")
     p.add_argument("--dry-run", action="store_true",
                    help="Print the diff but do not write anything.")
+    p.add_argument("--force", action="store_true",
+                   help="Add hooks even if the same hook is already registered "
+                        "in a sibling scope (would fire twice per event). See #99.")
     # Test hooks (hidden):
     p.add_argument("--home", default=None, help=argparse.SUPPRESS)
     p.add_argument("--cwd", default=None, help=argparse.SUPPRESS)
@@ -246,6 +306,35 @@ def run(argv: list[str] | None = None, *,
     if not added:
         print(f"Token Savior hooks already installed for {agent} ({target}).", file=stdout)
         return 0
+
+    # Cross-scope duplicate guard (#99). Claude Code merges hooks across
+    # ~/.claude, <project>/.claude and settings.local.json, so the same hook
+    # registered in two scopes fires twice per event. `added` only dedups
+    # within the file we are writing; here we look at the sibling scope.
+    if agent == "claude" and not args.force:
+        other_scope = "global" if scope == "local" else "local"
+        try:
+            sibling = settings_path(agent, other_scope, home=home, cwd=cwd)
+        except (RuntimeError, ValueError):
+            sibling = None
+        sibling_ids = _scope_hook_identities(sibling)
+        if sibling_ids:
+            kept, skipped = _strip_cross_scope(after, added, sibling_ids)
+            for event, (matcher, cmd) in skipped:
+                print(
+                    f"warning: {_hook_name(cmd)} already registered in {sibling} "
+                    f"({event}); skipping to avoid a double fire per event. "
+                    f"Pass --force to add it anyway.",
+                    file=stderr,
+                )
+            added = kept
+        if not added:
+            print(
+                f"All Token Savior hooks are already registered in a sibling scope "
+                f"for {agent}; nothing to add (use --force to override).",
+                file=stdout,
+            )
+            return 0
 
     # Show the diff.
     print(f"Target: {target}", file=stdout)

--- a/src/token_savior/daemon_client.py
+++ b/src/token_savior/daemon_client.py
@@ -20,7 +20,18 @@ import socket
 import struct
 from typing import Any
 
-_SOCK_PATH = os.environ.get("TS_SOCK", "/tmp/ts.sock")
+
+def _default_sock_path() -> str:
+    """Match cli._default_sock_path: per-user socket outside world-writable
+    /tmp (#98). Both sides must agree or the CLI and daemon miss each other."""
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime:
+        return os.path.join(runtime, "ts.sock")
+    cfg = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
+    return os.path.join(cfg, "ts", "ts.sock")
+
+
+_SOCK_PATH = os.environ.get("TS_SOCK") or _default_sock_path()
 
 
 def _send_frame(sock: socket.socket, obj: Any) -> None:

--- a/tests/test_bash_rewriter.py
+++ b/tests/test_bash_rewriter.py
@@ -86,13 +86,13 @@ def test_git_status_with_flag_skipped() -> None:
 
 def test_git_diff_bare() -> None:
     new, reason = rewrite("git diff")
-    assert new == "git diff --no-color --stat=200,5"
+    assert new == "git diff --no-color"
     assert reason
 
 
 def test_git_diff_with_positional_refs() -> None:
     new, _ = rewrite("git diff main feature")
-    assert new == "git diff --no-color --stat=200,5 main feature"
+    assert new == "git diff --no-color main feature"
 
 
 def test_git_diff_with_user_flag_skipped() -> None:

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -589,3 +589,39 @@ def test_run_works_for_every_supported_agent(fake_home: Path) -> None:
             "--dry-run",
         ])
         assert rc == 0, f"dry-run failed for {agent}"
+
+
+# --- cross-scope duplicate hook guard (#99) ---
+def test_ts_init_skips_hooks_already_in_sibling_scope(tmp_path: Path) -> None:
+    """A hook already in the global scope is not re-added locally — Claude Code
+    merges scopes, so it would fire twice per event (#99)."""
+    import io as _io
+    home = tmp_path / "home"
+    proj = tmp_path / "proj"
+    (home / ".claude").mkdir(parents=True)
+    (proj / ".claude").mkdir(parents=True)
+    common = ["--agent", "claude", "--yes", "--home", str(home),
+              "--cwd", str(proj), "--ts-root", str(REPO_ROOT)]
+    assert run(common + ["--global"]) == 0
+    errbuf = _io.StringIO()
+    rc = run(common + ["--local"], stdout=_io.StringIO(), stderr=errbuf)
+    assert rc == 0
+    assert "already registered" in errbuf.getvalue()
+    local_path = proj / ".claude" / "settings.json"
+    if local_path.exists():
+        local = json.loads(local_path.read_text())
+        assert not local.get("hooks", {}).get("PostToolUse")
+
+
+def test_ts_init_force_adds_despite_sibling_scope(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    proj = tmp_path / "proj"
+    (home / ".claude").mkdir(parents=True)
+    (proj / ".claude").mkdir(parents=True)
+    common = ["--agent", "claude", "--yes", "--home", str(home),
+              "--cwd", str(proj), "--ts-root", str(REPO_ROOT)]
+    assert run(common + ["--global"]) == 0
+    rc = run(common + ["--local", "--force"])
+    assert rc == 0
+    local = json.loads((proj / ".claude" / "settings.json").read_text())
+    assert local.get("hooks", {}).get("PostToolUse")

--- a/tests/test_daemon_client.py
+++ b/tests/test_daemon_client.py
@@ -88,3 +88,25 @@ def test_non_string_text_returns_none(sock_dir):
     out = daemon_client.call_daemon("ts_search", {"query": "x"}, sock_path=sock_path)
     t.join(timeout=5)
     assert out is None
+
+
+# --- socket path hardening (#98) ---
+def test_default_sock_path_prefers_xdg_runtime(monkeypatch):
+    """Socket defaults out of world-writable /tmp into a per-user dir (#98)."""
+    from token_savior import daemon_client
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    assert daemon_client._default_sock_path() == "/run/user/1000/ts.sock"
+
+
+def test_default_sock_path_falls_back_to_config(monkeypatch):
+    from token_savior import daemon_client
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/home/u/.config")
+    assert daemon_client._default_sock_path() == "/home/u/.config/ts/ts.sock"
+
+
+def test_default_sock_path_never_uses_tmp(monkeypatch):
+    from token_savior import daemon_client
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    assert not daemon_client._default_sock_path().startswith("/tmp/")

--- a/tests/test_tool_capture_hybrid.py
+++ b/tests/test_tool_capture_hybrid.py
@@ -276,3 +276,18 @@ def test_string_response_large_is_sandboxed(stub_sandbox, monkeypatch):
     assert "ts://capture/1" in note
     assert len(stub_sandbox) == 1
     assert stub_sandbox[0]["output"] == "y" * 10_000
+
+
+# ---------------------------------------------------------------------------
+# stderr-only output must be captured on the sandbox path (#100)
+# ---------------------------------------------------------------------------
+def test_stderr_only_output_is_captured(stub_sandbox, monkeypatch):
+    """A Bash command that writes only to stderr (test runners, linters) must
+    still be captured — not judged empty and dropped — on the sandbox path (#100)."""
+    # Must clear the 4096-byte capture threshold on the stderr stream alone.
+    stderr = "\n".join(f"E{i:03d}: assertion failed in the module under test, detail" for i in range(150))
+    event = _bash_event("pytest -q", stdout="", stderr=stderr)
+    # No TS_BASH_COMPACT + capture enabled: exercise the plain sandbox path.
+    _run_hook(event, monkeypatch, env={"TS_BASH_COMPACT": "0", "TS_CAPTURE_DISABLED": "0"})
+    assert stub_sandbox, "stderr-only output was never captured (fell under threshold)"
+    assert "assertion failed" in stub_sandbox[-1]["output"]


### PR DESCRIPTION
Four independent fixes, one commit + red→green test each. All flagged by @andrebrait.

**Closes #97** — `bash_rewriter` rewrote a bare `git diff` to `--stat=200,5`, turning the patch the agent asked for into a diffstat the PostToolUse layer could never recover. Keep only `--no-color`; leave output-side compaction to the GitDiffCompactor.

**Closes #98** — daemon socket defaulted to a predictable `/tmp/ts.sock` in a world-writable dir (squatting + PermissionError on sticky-bit remove). Default into `$XDG_RUNTIME_DIR/ts.sock` (else `~/.config/ts/ts.sock`), bind under `umask 0o177`, catch `OSError` on the stale-socket remove. `TS_SOCK` still overrides. cli.py and daemon_client.py kept in sync.

**Closes #99** — `ts init` deduped hooks only within the file it writes, so a hook registered in two Claude scopes fired twice. Now reads the sibling scope, skips `(matcher, hook-name)` collisions with a warning, `--force` to add anyway.

**Closes #100** — a Bash command writing only to stderr (test runners, linters) yielded empty content, fell under the threshold, and was never captured. Fold stderr into the threshold content; streams stay split for `_compact()` so stderr isn't double-counted.

Targeted suites green (120 passed), ruff clean.