### PR TITLE
feat(mcp): declare tool annotations at the protocol boundary

### DIFF
--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -582,9 +582,20 @@ _emit_startup_banner(
 async def list_tools() -> list:
     """MCP list_tools handler. Decorateur applique dans `run()` lazily."""
     # Convertit nos ToolDef locaux en mcp.types.Tool a la frontiere protocole.
+    # Les annotations disent au client ce que l'outil fait au monde : sans
+    # elles, le defaut du protocole est readOnlyHint=false + destructiveHint=
+    # true, donc `get_function_source` passe pour destructeur.
     from mcp.types import Tool as McpTool
+    from mcp.types import ToolAnnotations
+
+    from token_savior.tool_annotations import annotations_for
     return [
-        McpTool(name=t.name, description=t.description, inputSchema=t.inputSchema)
+        McpTool(
+            name=t.name,
+            description=t.description,
+            inputSchema=t.inputSchema,
+            annotations=ToolAnnotations(**annotations_for(t.name)),
+        )
         for t in TOOLS
     ]
 

--- a/src/token_savior/tool_annotations.py
+++ b/src/token_savior/tool_annotations.py
@@ -1,0 +1,114 @@
+"""Tool annotations (readOnlyHint & co) for the MCP protocol boundary.
+
+Why this module exists
+----------------------
+MCP lets a server declare, per tool, whether it only reads, whether it can
+destroy state, whether it is idempotent, and whether it reaches outside the
+machine. Clients use those hints to decide what an agent may call unattended.
+
+Without them the protocol defaults are hostile: `readOnlyHint` defaults to
+false and `destructiveHint` to true, so *every* Token Savior tool looks
+potentially destructive to a client — including `get_function_source`. Any
+consumer that wants a read-only subset then has to hard-code its own list and
+keep it in sync by hand. That list drifts silently the day a tool is added.
+
+The classification lives here, next to a test that fails if a tool in
+TOOL_SCHEMAS is not classified. Adding a tool without saying what it does to
+the world is a CI failure, not a silent mislabel.
+"""
+
+from __future__ import annotations
+
+# Tools that change state: files on disk, the index, memory, or the active
+# project. Everything not listed here is read-only.
+MUTATING_TOOLS = frozenset({
+    # structural code edits
+    "add_field_to_model",
+    "edit_lines_in_symbol",
+    "insert_near_symbol",
+    "move_symbol",
+    "replace_symbol_source",
+    # index / project state
+    "checkpoint",
+    "corpus_build",
+    "reindex",
+    "set_project_root",
+    "switch_project",
+    # persistent memory
+    "memory_admin",
+    "memory_delete",
+    "memory_save",
+    "reasoning_save",
+    # captures
+    "capture_purge",
+    "capture_put",
+    # execution — arbitrary side effects by construction
+    "run_impacted_tests",
+    "run_project_action",
+    "ts_execute",
+})
+
+# Subset of MUTATING_TOOLS that can overwrite or remove existing state, as
+# opposed to only adding to it. `insert_near_symbol` adds a symbol and is not
+# listed; `replace_symbol_source` overwrites one and is.
+#
+# The three execution tools are listed conservatively: what a project action
+# or a sandbox script does is not knowable from here, so we do not promise a
+# client that it is safe.
+DESTRUCTIVE_TOOLS = frozenset({
+    "add_field_to_model",
+    "capture_purge",
+    "edit_lines_in_symbol",
+    "memory_admin",
+    "memory_delete",
+    "move_symbol",
+    "replace_symbol_source",
+    "run_project_action",
+    "ts_execute",
+})
+
+# Mutating tools where calling twice with the same arguments leaves the same
+# state as calling once. Read-only tools are idempotent by definition and are
+# not repeated here.
+#
+# `checkpoint` and `capture_put` are absent on purpose: each call creates a new
+# snapshot or a new capture row.
+IDEMPOTENT_MUTATORS = frozenset({
+    "capture_purge",
+    "corpus_build",
+    "memory_delete",
+    "reindex",
+    "set_project_root",
+    "switch_project",
+})
+
+# Nothing here talks to the network: Token Savior indexes and edits a local
+# working copy. Kept as a named constant so a future tool that does reach out
+# has an obvious place to break the assumption.
+OPEN_WORLD_TOOLS: frozenset[str] = frozenset()
+
+
+def annotations_for(name: str) -> dict[str, bool]:
+    """Return the MCP annotation hints for one tool, by name.
+
+    Unknown names are treated as read-only: `TOOL_SCHEMAS` is the source of
+    truth for what exists, and `test_tool_annotations` guarantees every entry
+    in it is classified here, so an unknown name at runtime is a filtered or
+    legacy tool rather than an unclassified mutator.
+    """
+    read_only = name not in MUTATING_TOOLS
+    return {
+        "readOnlyHint": read_only,
+        "destructiveHint": (not read_only) and name in DESTRUCTIVE_TOOLS,
+        "idempotentHint": read_only or name in IDEMPOTENT_MUTATORS,
+        "openWorldHint": name in OPEN_WORLD_TOOLS,
+    }
+
+
+def read_only_tool_names(all_names: object) -> frozenset[str]:
+    """The read-only subset of `all_names`.
+
+    Exposed so consumers that need a safe list — a judge loop, a review agent —
+    can derive it from the server instead of maintaining their own copy.
+    """
+    return frozenset(n for n in all_names if n not in MUTATING_TOOLS)

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,0 +1,187 @@
+"""Les annotations MCP doivent couvrir tous les outils, sans exception.
+
+Le risque que ces tests ferment : un outil qui ecrit sur disque est ajoute a
+TOOL_SCHEMAS, personne ne pense a le declarer mutateur, et il part au client
+annonce `readOnlyHint=true`. Un juge en lecture seule l'appellerait alors en
+toute confiance. Une liste maintenue a la main derive en silence ; ces tests
+transforment la derive en echec de CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from token_savior.tool_annotations import (
+    DESTRUCTIVE_TOOLS,
+    IDEMPOTENT_MUTATORS,
+    MUTATING_TOOLS,
+    OPEN_WORLD_TOOLS,
+    annotations_for,
+    read_only_tool_names,
+)
+from token_savior.tool_schemas import TOOL_SCHEMAS
+
+
+def test_every_classified_tool_exists():
+    """Aucun nom fantome dans les ensembles de classification.
+
+    Un outil renomme ou supprime laisse son ancien nom dans MUTATING_TOOLS ; la
+    protection devient alors decorative et personne ne le voit.
+    """
+    known = set(TOOL_SCHEMAS)
+    for label, names in (
+        ("MUTATING_TOOLS", MUTATING_TOOLS),
+        ("DESTRUCTIVE_TOOLS", DESTRUCTIVE_TOOLS),
+        ("IDEMPOTENT_MUTATORS", IDEMPOTENT_MUTATORS),
+        ("OPEN_WORLD_TOOLS", OPEN_WORLD_TOOLS),
+    ):
+        orphelins = sorted(names - known)
+        assert not orphelins, f"{label} cite des outils inexistants : {orphelins}"
+
+
+def test_destructive_and_idempotent_are_mutators():
+    """Un outil ne peut pas etre destructeur ou mutateur-idempotent sans muter."""
+    assert not (DESTRUCTIVE_TOOLS - MUTATING_TOOLS)
+    assert not (IDEMPOTENT_MUTATORS - MUTATING_TOOLS)
+
+
+def test_destructive_and_idempotent_are_exclusive():
+    """Rien ne peut etre a la fois destructeur et sans effet supplementaire.
+
+    Exception assumee : une suppression est les deux (supprimer deux fois
+    laisse le meme etat). On l'autorise explicitement plutot que par accident.
+    """
+    suppressions = {"capture_purge", "memory_delete"}
+    chevauchement = (DESTRUCTIVE_TOOLS & IDEMPOTENT_MUTATORS) - suppressions
+    assert not chevauchement, f"classement contradictoire : {sorted(chevauchement)}"
+
+
+@pytest.mark.parametrize("name", sorted(TOOL_SCHEMAS))
+def test_every_tool_gets_complete_annotations(name):
+    """Les quatre hints sont produits, et typés bool, pour chaque outil."""
+    ann = annotations_for(name)
+    assert set(ann) == {
+        "readOnlyHint",
+        "destructiveHint",
+        "idempotentHint",
+        "openWorldHint",
+    }
+    assert all(isinstance(v, bool) for v in ann.values())
+
+
+def test_read_only_tools_are_never_destructive():
+    """Le cas qui compte : rien d'annonce lisible ne peut detruire."""
+    for name in TOOL_SCHEMAS:
+        ann = annotations_for(name)
+        if ann["readOnlyHint"]:
+            assert not ann["destructiveHint"], name
+            assert ann["idempotentHint"], name
+
+
+def test_known_mutators_are_flagged():
+    """Garde-fou en dur sur les outils dont la nature ne doit jamais glisser.
+
+    Ecrits en litteral : si quelqu'un retire `replace_symbol_source` de
+    MUTATING_TOOLS, le test qui derive tout de cet ensemble ne verrait rien.
+    """
+    for name in (
+        "replace_symbol_source",
+        "move_symbol",
+        "edit_lines_in_symbol",
+        "add_field_to_model",
+        "insert_near_symbol",
+        "memory_delete",
+        "memory_save",
+        "reindex",
+        "switch_project",
+        "ts_execute",
+        "run_project_action",
+        "run_impacted_tests",
+    ):
+        assert name in TOOL_SCHEMAS, f"outil disparu du manifeste : {name}"
+        assert not annotations_for(name)["readOnlyHint"], f"{name} annonce lisible"
+
+
+def test_known_readers_are_flagged():
+    """Symetrique : les outils de lecture pure ne doivent pas devenir opaques."""
+    for name in (
+        "get_function_source",
+        "get_full_context",
+        "search_codebase",
+        "find_symbol",
+        "list_files",
+        "get_git_status",
+        "memory_search",
+    ):
+        assert name in TOOL_SCHEMAS, f"outil disparu du manifeste : {name}"
+        ann = annotations_for(name)
+        assert ann["readOnlyHint"], f"{name} devrait etre lisible"
+        assert not ann["openWorldHint"], f"{name} ne sort pas de la machine"
+
+
+# Verbes qui, dans un nom d'outil, annoncent une ecriture. La liste est
+# volontairement large : un faux positif se resout en une ligne ci-dessous,
+# un faux negatif expose un mutateur annonce comme lisible.
+_VERBES_ECRITURE = (
+    "add_", "apply_", "build", "checkpoint", "delete", "edit_", "execute",
+    "insert_", "move_", "purge", "put", "reindex", "replace_", "run_",
+    "save", "set_", "switch_", "write",
+)
+
+# Outils dont le nom contient un verbe d'ecriture mais qui ne touchent a rien.
+# Toute entree ici est une derogation assumee, pas un oubli.
+_LECTEURS_MALGRE_LE_NOM: frozenset[str] = frozenset({
+    "build_commit_summary",  # produit un texte, n'ecrit pas
+    "discover_project_actions",  # liste les actions, ne les lance pas
+    "get_edit_context",  # rassemble le contexte AVANT une edition, sans editer
+})
+
+
+def test_no_unclassified_writer_slips_through():
+    """Cherche l'ABSENCE de classification, pas sa presence.
+
+    `annotations_for` traite un nom inconnu comme lisible. C'est le bon defaut
+    a l'execution, mais ca veut dire qu'un mutateur ajoute sans etre declare
+    partirait au client annonce `readOnlyHint=true` sans qu'aucun autre test
+    ne bronche. Ce test-ci est le seul qui attrape ce cas.
+    """
+    suspects = sorted(
+        name
+        for name in TOOL_SCHEMAS
+        if any(v in name for v in _VERBES_ECRITURE)
+        and name not in MUTATING_TOOLS
+        and name not in _LECTEURS_MALGRE_LE_NOM
+    )
+    assert not suspects, (
+        "outils au nom d'ecriture mais absents de MUTATING_TOOLS : "
+        f"{suspects}. Classe-les, ou ajoute-les a _LECTEURS_MALGRE_LE_NOM "
+        "en disant pourquoi ils n'ecrivent rien."
+    )
+
+
+def test_read_only_subset_matches_annotations():
+    """`read_only_tool_names` et `annotations_for` ne peuvent pas diverger."""
+    derive = read_only_tool_names(TOOL_SCHEMAS)
+    attendu = {n for n in TOOL_SCHEMAS if annotations_for(n)["readOnlyHint"]}
+    assert derive == attendu
+
+
+def test_list_tools_advertises_annotations():
+    """Le handler protocole transmet bien les hints, pas seulement le module."""
+    import asyncio
+
+    from token_savior.server import list_tools
+
+    tools = asyncio.run(list_tools())
+    assert tools, "aucun outil annonce"
+    for t in tools:
+        assert t.annotations is not None, f"{t.name} sans annotations"
+        assert isinstance(t.annotations.readOnlyHint, bool), t.name
+
+    par_nom = {t.name: t for t in tools}
+    if "get_function_source" in par_nom:
+        assert par_nom["get_function_source"].annotations.readOnlyHint is True
+        assert par_nom["get_function_source"].annotations.destructiveHint is False
+    if "replace_symbol_source" in par_nom:
+        assert par_nom["replace_symbol_source"].annotations.readOnlyHint is False
+        assert par_nom["replace_symbol_source"].annotations.destructiveHint is True


### PR DESCRIPTION
## Le problème

Sans annotations, les défauts du protocole MCP sont hostiles : `readOnlyHint` vaut `false` et `destructiveHint` vaut `true` par défaut. Résultat, les 69 outils arrivent chez le client annoncés comme potentiellement destructeurs, `get_function_source` compris.

Conséquence concrète : tout consommateur qui veut un sous-ensemble lecture seule (une boucle de juge, un agent de revue) doit maintenir sa propre liste à la main. Cette liste dérive en silence le jour où un outil est ajouté.

## Ce que fait la PR

- `tool_annotations.py` classe les 69 outils une fois pour toutes : mutateur, destructeur, idempotent, ouvert sur le réseau.
- `list_tools()` transmet les quatre hints à la frontière protocole.
- `read_only_tool_names()` est exporté pour que les consommateurs dérivent l'ensemble sûr du serveur au lieu d'en garder une copie.

## Ce qui garde la classification

Une classification ne vaut que ce que valent ses garde-fous. `annotations_for` traite un nom inconnu comme lisible, ce qui est le bon défaut à l'exécution mais laisserait passer un mutateur ajouté sans être déclaré.

`test_no_unclassified_writer_slips_through` cherche donc **l'absence** de classification : tout outil dont le nom porte un verbe d'écriture et qui manque à `MUTATING_TOOLS` fait échouer la CI. Trois lecteurs dont le nom ressemble à une écriture (`get_edit_context`, `build_commit_summary`, `discover_project_actions`) sont dérogés explicitement.

## Vérification

- 78 tests dans le nouveau fichier, `preflight.sh` vert (2958 passed, 5 skipped).
- Test de mutation : retirer `replace_symbol_source` de `MUTATING_TOOLS` casse 3 tests. Les tests contraignent réellement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBt6BMaSDJRcq4bkg1xxJq