### PR TITLE
feat(dispatch): say when a result was cut by its own bound

### DIFF
--- a/src/token_savior/server_runtime.py
+++ b/src/token_savior/server_runtime.py
@@ -591,6 +591,17 @@ def _count_and_wrap_result(
         except Exception:
             pass
 
+    # Une reponse coupee par sa borne est indiscernable d'une reponse complete :
+    # l'appelant qui compte croit mesurer un total et mesure la borne. On le dit.
+    # Voir truncation.py pour pourquoi ce n'est pas de la pagination.
+    try:
+        from token_savior.truncation import notice_de_troncature
+        notice = notice_de_troncature(arguments, result)
+        if notice:
+            formatted = f"{formatted}\n{notice}"
+    except Exception:
+        pass
+
     if slot.stats_file:
         _flush_stats(slot, s._total_naive_chars)
 

--- a/src/token_savior/truncation.py
+++ b/src/token_savior/truncation.py
@@ -1,0 +1,132 @@
+"""Rendre visible une reponse tronquee par sa borne.
+
+Le probleme, tel qu'il se paie
+------------------------------
+Vingt-neuf outils acceptent une borne (`limit`, `max_results`, `top_k`,
+`max_groups`, `max_files`) et la respectent. Aucun ne dit s'il a coupe. Une
+reponse de exactement `max_results` elements est donc indiscernable d'une
+reponse complete.
+
+L'appelant qui compte ces elements ne mesure pas ce qu'il croit mesurer : deux
+comptages qui tombent tous les deux sur la borne ne veulent pas dire
+« deux valeurs egales », ils veulent dire « deux troncatures ». L'erreur est
+silencieuse par construction et ne se voit qu'en relisant la borne.
+
+Ce module ne fait pas de la pagination. Il ne sait ni combien d'elements
+existaient au total, ni ou reprendre : le handler a deja coupe quand on arrive
+ici. Il ferme la classe d'erreur — « je ne sais pas que je n'ai pas tout » — et
+laisse `has_more`/`next_offset`/`total_count` a une passe par handler.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Bornes qui gouvernent le NOMBRE d'elements d'une collection. Ce sont les
+# seules comparables a la longueur d'une liste. Tenu a jour par
+# test_truncation::test_bornes_couvrent_les_schemas, qui echoue si un outil
+# introduit une borne sous un nom inconnu d'ici.
+NOMS_DE_BORNE = (
+    "limit",
+    "max_results",
+    "top_k",
+    "max_groups",
+    "max_files",
+    "max_tests",
+    "max_issues",
+    "max_cycles",
+    "max_deps",
+    "max_callers",
+    "max_direct",
+    "max_transitive",
+)
+
+# Bornes qui gouvernent une TAILLE (octets, lignes, caracteres), pas un nombre
+# d'elements. Les comparer a la longueur d'une liste n'a aucun sens et
+# produirait des alertes au hasard. Elles sont listees pour que le test de
+# couverture ne les reclame pas, et pour que la distinction reste ecrite.
+#
+# `max_symbols_per_file` est ici pour une autre raison : il borne les symboles
+# DANS chaque fichier, pas la collection rendue. Le comparer au total serait
+# faux dans les deux sens.
+BORNES_DE_TAILLE = (
+    "max_bytes",
+    "max_lines",
+    "max_output_chars",
+    "max_total_chars",
+    "max_symbols_per_file",
+)
+
+
+def _entier_positif(valeur: object) -> int | None:
+    if isinstance(valeur, bool):  # bool est un int en Python
+        return None
+    if isinstance(valeur, int) and valeur > 0:
+        return valeur
+    if isinstance(valeur, str) and valeur.isdigit() and int(valeur) > 0:
+        return int(valeur)
+    return None
+
+
+def _bornes_demandees(arguments: dict[str, Any]) -> set[int]:
+    """Toutes les bornes de collection exploitables passees par l'appelant.
+
+    Un meme appel peut en porter plusieurs (`get_change_impact` a `max_direct`
+    ET `max_transitive`). En retenir une seule, arbitrairement la premiere,
+    ferait manquer la troncature gouvernee par l'autre.
+    """
+    valeurs = set()
+    for cle in NOMS_DE_BORNE:
+        n = _entier_positif(arguments.get(cle))
+        if n is not None:
+            valeurs.add(n)
+    return valeurs
+
+
+def _plus_longue_liste(result: object, profondeur: int = 0) -> tuple[str, int] | None:
+    """(chemin, longueur) de la plus longue liste du resultat.
+
+    On ne descend que de deux niveaux : au-dela, une liste longue est un detail
+    interne (des lignes, des tokens) et pas la collection que la borne
+    gouverne. Signaler celle-la produirait un faux positif.
+    """
+    if isinstance(result, list):
+        return ("", len(result))
+    if isinstance(result, dict) and profondeur < 2:
+        meilleur: tuple[str, int] | None = None
+        for cle, valeur in result.items():
+            trouve = _plus_longue_liste(valeur, profondeur + 1)
+            if trouve is None:
+                continue
+            chemin = cle if not trouve[0] else f"{cle}.{trouve[0]}"
+            candidat = (chemin, trouve[1])
+            if meilleur is None or candidat[1] > meilleur[1]:
+                meilleur = candidat
+        return meilleur
+    return None
+
+
+def notice_de_troncature(arguments: dict[str, Any], result: object) -> str | None:
+    """Message a ajouter si le resultat est probablement coupe, sinon None.
+
+    Le critere est l'egalite stricte entre la longueur rendue et la borne
+    demandee. C'est volontairement conservateur : une collection qui compte
+    pile `limit` elements sans avoir ete coupee produit un faux positif, mais
+    un faux positif se lit et se corrige, alors qu'un faux negatif est
+    exactement le silence qu'on cherche a supprimer.
+    """
+    bornes = _bornes_demandees(arguments)
+    if not bornes:
+        return None
+    trouve = _plus_longue_liste(result)
+    if trouve is None:
+        return None
+    chemin, longueur = trouve
+    if longueur not in bornes:
+        return None
+    ou = f" ({chemin})" if chemin else ""
+    return (
+        f"[tronque] {longueur} element(s){ou} rendus, soit exactement la borne "
+        f"demandee — il en reste probablement. Relance avec une borne plus "
+        f"haute avant de conclure sur ce compte."
+    )

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,0 +1,123 @@
+"""Une reponse coupee par sa borne doit le dire.
+
+Le faux negatif qu'on ferme : un outil rend pile `max_results` elements,
+l'appelant compte, et croit tenir un total. Deux comptages qui saturent tous
+les deux la borne se lisent comme deux valeurs egales alors que ce sont deux
+troncatures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from token_savior.tool_schemas import TOOL_SCHEMAS
+from token_savior.truncation import (
+    BORNES_DE_TAILLE,
+    NOMS_DE_BORNE,
+    notice_de_troncature,
+)
+
+
+def test_liste_saturee_est_signalee():
+    notice = notice_de_troncature({"max_results": 3}, ["a", "b", "c"])
+    assert notice is not None
+    assert "tronque" in notice
+    assert "3" in notice
+
+
+def test_liste_non_saturee_est_muette():
+    assert notice_de_troncature({"max_results": 10}, ["a", "b", "c"]) is None
+
+
+def test_sans_borne_pas_de_bruit():
+    """Un appel sans borne explicite n'a rien a signaler."""
+    assert notice_de_troncature({}, ["a", "b", "c"]) is None
+
+
+def test_liste_imbriquee_dans_un_dict():
+    notice = notice_de_troncature({"limit": 2}, {"matches": [1, 2], "total_files": 9})
+    assert notice is not None
+    assert "matches" in notice
+
+
+def test_la_plus_longue_liste_gagne():
+    """La borne gouverne la collection principale, pas un detail annexe."""
+    resultat = {"symbols": [1, 2, 3, 4], "warnings": ["x"]}
+    notice = notice_de_troncature({"max_results": 4}, resultat)
+    assert notice is not None and "symbols" in notice
+
+
+def test_profondeur_bornee():
+    """Une liste enfouie a trois niveaux est un detail interne, pas la collection.
+
+    Sans cette borne de profondeur, une liste de lignes ou de tokens dont la
+    longueur coincide avec `limit` produirait une alerte a chaque appel, et une
+    alerte qui crie tout le temps ne se lit plus.
+    """
+    profond = {"a": {"b": {"c": [1, 2, 3]}}}
+    assert notice_de_troncature({"limit": 3}, profond) is None
+
+
+def test_borne_booleenne_ignoree():
+    """`True` vaut 1 en Python : un flag ne doit pas passer pour une borne."""
+    assert notice_de_troncature({"limit": True}, ["seul"]) is None
+
+
+def test_borne_en_chaine_acceptee():
+    """Les arguments arrivent parfois en chaine depuis le protocole."""
+    assert notice_de_troncature({"limit": "2"}, ["a", "b"]) is not None
+
+
+def test_borne_negative_ou_nulle_ignoree():
+    assert notice_de_troncature({"limit": 0}, []) is None
+    assert notice_de_troncature({"limit": -5}, []) is None
+
+
+def test_resultat_sans_liste():
+    assert notice_de_troncature({"limit": 3}, {"source": "def f(): pass"}) is None
+    assert notice_de_troncature({"limit": 3}, "texte brut") is None
+
+
+def test_bornes_couvrent_les_schemas():
+    """Aucun outil ne doit introduire une borne sous un nom inconnu d'ici.
+
+    Sans ce test, un futur `max_items` tronquerait en silence : le module ne le
+    reconnaitrait pas comme une borne et ne signalerait jamais rien.
+    """
+    connues = set(NOMS_DE_BORNE) | set(BORNES_DE_TAILLE)
+    suspects = {}
+    for nom, schema in TOOL_SCHEMAS.items():
+        props = (schema.get("inputSchema") or {}).get("properties") or {}
+        for cle in props:
+            c = cle.lower()
+            if c in connues:
+                continue
+            if c.startswith("max_") or c in {"limit", "top_k", "count", "n_results"}:
+                suspects.setdefault(nom, []).append(cle)
+    assert not suspects, (
+        f"bornes non reconnues par truncation.py : {suspects}. Classe-les : "
+        "dans NOMS_DE_BORNE si elles bornent un NOMBRE d'elements, dans "
+        "BORNES_DE_TAILLE si elles bornent des octets ou des lignes. Sinon ces "
+        "outils tronqueront en silence."
+    )
+
+
+def test_bornes_de_taille_ne_declenchent_rien():
+    """Une borne d'octets ou de lignes n'a rien a voir avec un nombre d'elements."""
+    for cle in BORNES_DE_TAILLE:
+        assert notice_de_troncature({cle: 3}, ["a", "b", "c"]) is None, cle
+
+
+def test_plusieurs_bornes_dans_le_meme_appel():
+    """`get_change_impact` porte max_direct ET max_transitive.
+
+    N'en retenir qu'une ferait manquer la troncature gouvernee par l'autre.
+    """
+    assert notice_de_troncature(
+        {"max_direct": 10, "max_transitive": 2}, {"transitive": ["a", "b"]}
+    ) is not None
+
+
+@pytest.mark.parametrize("cle", NOMS_DE_BORNE)
+def test_chaque_nom_de_borne_fonctionne(cle):
+    assert notice_de_troncature({cle: 2}, ["a", "b"]) is not None


### PR DESCRIPTION
## Le problème

41 outils acceptent une borne et la respectent. Aucun ne dit qu'il a coupé.

Une réponse de exactement `max_results` éléments est donc indiscernable d'une réponse complète. L'appelant qui compte croit mesurer un total et mesure la borne : deux comptages qui saturent tous les deux la limite se lisent comme deux valeurs égales alors que ce sont deux troncatures. L'erreur est silencieuse par construction.

## Ce que fait la PR

`truncation.py` ajoute la notice au **point unique** où un résultat brut de handler est emballé, et sépare deux choses que les schémas confondent :

- les bornes qui gouvernent un **nombre** d'éléments, comparables à une longueur de liste ;
- les bornes qui gouvernent une **taille** en octets ou en lignes, comparables à rien.

`max_symbols_per_file` est rangé avec les bornes de taille pour une troisième raison : il plafonne les symboles **dans chaque fichier**, donc le comparer au total serait faux dans les deux sens.

Les bornes multiples d'un même appel sont toutes prises en compte : `get_change_impact` porte `max_direct` **et** `max_transitive`, n'en garder qu'une ferait manquer la troncature gouvernée par l'autre.

## Ce que les tests contraignent

`test_bornes_couvrent_les_schemas` échoue dès qu'un outil introduit une borne sous un nom inconnu. Il a déjà trouvé **14 bornes** qu'un inventaire à la main avait ratées (`max_tests`, `max_cycles`, `max_deps`, `max_callers`, `max_issues`…).

Vérifié par mutation : neutraliser la notice casse 17 tests.

Faux positif assumé : une collection qui compte pile `limit` éléments sans avoir été coupée déclenche l'alerte. Un faux positif se lit et se corrige, un faux négatif est exactement le silence qu'on supprime.

## Ce que ce n'est pas

Ce n'est pas de la pagination. À cet endroit le handler a déjà coupé, donc `total_count` et `next_offset` ne sont pas connaissables. La passe par handler reste à faire.

`preflight.sh` vert : 2989 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBt6BMaSDJRcq4bkg1xxJq