### PR TITLE
Parallel worktrees: per-call routing, validated boot signals, no stolen active project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased — One server, many worktrees, no stolen calls
+
+Parallel agents in sibling worktrees shared one server and one mutable
+`active_root`, and the worktree a session actually worked in was often never
+even registered. Verified against the hosts, not their folklore: Claude Code
+exports `CLAUDE_PROJECT_DIR` (stable — always the main checkout, never the
+worktree); `CLAUDE_PROJECT_ROOT` is set by no host at all; Codex exports no
+path variable and whitelist-filters the MCP server environment, so only the
+spawn cwd carries its signal.
+
+- **Per-call routing by absolute path.** A call with no `project` hint but an
+  absolute `file_path`/`path`/`target_file` now routes to the tree that owns
+  the path — nearest marker root, so a worktree nested in a registered repo
+  (`repo/.claude/worktrees/wt`) wins over the parent checkout that contains
+  it. A linked worktree's `.git` *file* counts as a marker. The owning root
+  registers on the fly, and the shared `active_root` is never touched.
+- **Path hints resolve to their owner.** `project=` hints that are paths go
+  through the same nearest-root routing; a subdirectory of a registered
+  project no longer gets registered as a project of its own. Removed a
+  literally duplicated reverse-containment/register block in `resolve()`.
+- **Boot signals, validated and ranked.** `CLAUDE_PROJECT_ROOT` (deliberate,
+  ours: may register, always wins) → launch-directory root (the only signal
+  that follows worktrees and the only one Codex has; when it is a linked
+  worktree it takes active) → `CLAUDE_PROJECT_DIR` (automatic: promotes among
+  registered roots, never registers — pytest under Claude Code would adopt
+  the developer's repo at import otherwise). A candidate counts only if it
+  exists and carries a project marker. The launch directory now always gets
+  a slot even when `WORKSPACE_ROOTS` pinned the registry.
+- **`TS_STICKY_ACTIVE=1`** freezes `active_root` for multi-agent sessions:
+  explicit hints and path arguments still route every call, but no call
+  repoints the default the other agents fall back to.
+- Hooks and the standalone CLI now fall back `CLAUDE_PROJECT_ROOT` →
+  `CLAUDE_PROJECT_DIR` → `$PWD`; the session-start memory hook previously
+  read only the first, which no host sets, and ran with an empty project.
+
 ## v4.20.0 — What the tools promise, now measured (2026-07-27)
 
 Fourteen defects, found by exercising all 69 tools on a real machine rather

--- a/README.md
+++ b/README.md
@@ -322,8 +322,10 @@ values shown as *bool* accept `1`/`true`/`yes` (and `on` where noted).
 
 | Var | Default | Purpose |
 |---|---|---|
-| `WORKSPACE_ROOTS` | current dir | Comma-separated project roots to index |
+| `WORKSPACE_ROOTS` | current dir | Comma-separated project roots to index. Codex trap: Codex whitelist-filters the MCP server environment, so an exported shell variable never arrives — set it in `config.toml` under `[mcp_servers.token-savior] env` (or `env_vars`) |
 | `PROJECT_ROOT` | — | Single-root alternative to `WORKSPACE_ROOTS` |
+| `CLAUDE_PROJECT_ROOT` | — | Deliberate active-project override (Token Savior's own contract — no host sets it). Registered if valid, wins over every other boot signal |
+| `TS_STICKY_ACTIVE` | off (*bool*, `on` ok) | Freeze the active project: explicit `project=` hints and absolute path arguments still route each call, but no call repoints the shared default. For parallel agents in sibling worktrees |
 | `TOKEN_SAVIOR_PROFILE` | `full` | Tool profile. `optimized` — the value the quickstart config and `ts init` recommend — ships the Pareto manifest, implies thin schemas, and omits the capture tools from the manifest |
 | `TS_THIN_SCHEMAS=1` | off (on in `optimized`) | Strip verbose tool schemas from the manifest |
 | `TS_AUTO_HOT_K` | `10` | Hot-tool count exposed by the telemetry-driven `auto` profile |
@@ -387,9 +389,13 @@ values shown as *bool* accept `1`/`true`/`yes` (and `on` where noted).
 | `TOKEN_SAVIOR_DEBUG=1` | off | Debug logging |
 | `TOKEN_SAVIOR_TRACE` | off (*bool*) | MCP request lifecycle tracing |
 
-Not knobs: `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_PROJECT_ROOT`,
+Not knobs: `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_PROJECT_DIR`,
 `CLAUDE_CONTEXT_REMAINING_PCT`, `CODEX_*` and `HERMES_*` are read for host/client
-detection — the environment sets them, you don't.
+detection and boot-time project hints — the environment sets them, you don't.
+(`CLAUDE_PROJECT_DIR` is what Claude Code actually exports; it always names the
+main checkout, never the worktree the session works in, so the launch directory
+outranks it when that directory is a linked worktree. `CLAUDE_PROJECT_ROOT`
+moved up into the knobs table: nothing sets it but you.)
 
 Naming trap: `TS_PROFILE` in the benchmark snippets is **tsbench's** variable;
 the server reads `TOKEN_SAVIOR_PROFILE`.

--- a/hooks/memory-session-start.sh
+++ b/hooks/memory-session-start.sh
@@ -67,7 +67,7 @@ import sys, os, json
 sys.path.insert(0, '$TS_SRC')
 from token_savior import memory_db
 
-project = os.environ.get('CLAUDE_PROJECT_ROOT', '')
+project = os.environ.get('CLAUDE_PROJECT_ROOT') or os.environ.get('CLAUDE_PROJECT_DIR') or os.environ.get('PWD', '')
 
 # Adaptive budget based on remaining context
 try:
@@ -200,7 +200,7 @@ if [ "$INJECTED_TOKENS" -gt 0 ]; then
 import sys, os
 sys.path.insert(0, '$TS_SRC')
 from token_savior import memory_db
-project = os.environ.get('CLAUDE_PROJECT_ROOT', '')
+project = os.environ.get('CLAUDE_PROJECT_ROOT') or os.environ.get('CLAUDE_PROJECT_DIR') or os.environ.get('PWD', '')
 if not project:
     db = memory_db.get_db()
     row = db.execute('SELECT project_root FROM observations GROUP BY project_root ORDER BY COUNT(*) DESC LIMIT 1').fetchone()
@@ -232,7 +232,7 @@ from token_savior.session_warmstart import SessionWarmStart, compute_signature
 from token_savior.markov_prefetcher import PPMPrefetcher
 from token_savior import memory_db
 
-project = os.environ.get('CLAUDE_PROJECT_ROOT', '')
+project = os.environ.get('CLAUDE_PROJECT_ROOT') or os.environ.get('CLAUDE_PROJECT_DIR') or os.environ.get('PWD', '')
 if not project:
     db = memory_db.get_db()
     row = db.execute('SELECT project_root FROM observations GROUP BY project_root ORDER BY COUNT(*) DESC LIMIT 1').fetchone()
@@ -302,7 +302,7 @@ import sys, os
 sys.path.insert(0, '$TS_SRC')
 from token_savior import memory_db
 
-project = os.environ.get('CLAUDE_PROJECT_ROOT', '')
+project = os.environ.get('CLAUDE_PROJECT_ROOT') or os.environ.get('CLAUDE_PROJECT_DIR') or os.environ.get('PWD', '')
 db = memory_db.get_db()
 if not project:
     row = db.execute(
@@ -347,7 +347,7 @@ import sys, os
 sys.path.insert(0, '$TS_SRC')
 from token_savior import memory_db
 
-project = os.environ.get('CLAUDE_PROJECT_ROOT', '')
+project = os.environ.get('CLAUDE_PROJECT_ROOT') or os.environ.get('CLAUDE_PROJECT_DIR') or os.environ.get('PWD', '')
 if not project:
     db = memory_db.get_db()
     row = db.execute(

--- a/hooks/memory-session-stop.sh
+++ b/hooks/memory-session-stop.sh
@@ -83,7 +83,7 @@ PY=$TS_PY
 if [ "$TS_TURN_CAPTURE_DISABLE" != "1" ] && [ ! -t 0 ]; then
     HOOK_INPUT=$(timeout 2 cat 2>/dev/null || true)
     if [ -n "$HOOK_INPUT" ]; then
-        TC_PROJECT="${CLAUDE_PROJECT_ROOT:-$PWD}"
+        TC_PROJECT="${CLAUDE_PROJECT_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}"
         printf '%s' "$HOOK_INPUT" | (
             "$PY" -c "
 import sys, json
@@ -143,7 +143,7 @@ import sys, os, json, time
 sys.path.insert(0, '$TS_SRC')
 from token_savior import memory_db
 
-project = os.environ.get('CLAUDE_PROJECT_ROOT', '')
+project = os.environ.get('CLAUDE_PROJECT_ROOT') or os.environ.get('CLAUDE_PROJECT_DIR') or os.environ.get('PWD', '')
 db = memory_db.get_db()
 if not project:
     row = db.execute(

--- a/scripts/ts_cli.py
+++ b/scripts/ts_cli.py
@@ -14,7 +14,9 @@ from token_savior import memory_db
 def _resolve_project(explicit: str | None) -> str:
     if explicit:
         return explicit
-    env = os.environ.get("CLAUDE_PROJECT_ROOT")
+    # CLAUDE_PROJECT_ROOT is our own contract (user-set); CLAUDE_PROJECT_DIR
+    # is what Claude Code actually exports. Codex exports neither.
+    env = os.environ.get("CLAUDE_PROJECT_ROOT") or os.environ.get("CLAUDE_PROJECT_DIR")
     if env:
         return env
     db = memory_db.get_db()

--- a/src/token_savior/server.py
+++ b/src/token_savior/server.py
@@ -1023,6 +1023,24 @@ def _message_argument_obligatoire(name: str, exc: KeyError) -> str | None:
         f"or ts_search(query=...)."
     )
 
+# Argument names that carry a file location. An ABSOLUTE value is a per-call
+# routing signal: it says which tree the caller is actually working in, which
+# a shared `active_root` cannot (parallel agents, one server, several nested
+# worktrees — the worktree files live under the parent checkout, but belong
+# to a different project slot). Relative values stay project-relative by
+# contract and carry no signal.
+_PATH_ARG_KEYS = ("file_path", "path", "target_file")
+
+
+def _implicit_project_path(arguments: dict[str, Any]) -> str | None:
+    """First absolute filesystem path found among the call's path arguments."""
+    for key in _PATH_ARG_KEYS:
+        value = arguments.get(key)
+        if isinstance(value, str) and os.path.isabs(value):
+            return value
+    return None
+
+
 def _dispatch_tool(name: str, arguments: dict[str, Any], record_symbol: str) -> list[types.TextContent]:
     """Dispatch a tool by name, honoring the four handler categories.
 
@@ -1046,14 +1064,30 @@ def _dispatch_tool(name: str, arguments: dict[str, Any], record_symbol: str) -> 
             return [TextContent(type="text", text=mem_handler(arguments))]
 
         project_hint = arguments.get("project")
-        slot, err = s._slot_mgr.resolve(project_hint)
+        slot = None
+        err = ""
+        if not project_hint:
+            # No explicit project: an absolute path argument routes this one
+            # call to the tree it actually lives in (nearest marker root, so
+            # a nested worktree wins over the parent checkout that contains
+            # it) without consulting — or mutating — the shared active_root.
+            implicit = _implicit_project_path(arguments)
+            if implicit is not None:
+                slot = s._slot_mgr.resolve_path(implicit)
+        if slot is None:
+            slot, err = s._slot_mgr.resolve(project_hint)
         if err:
             return [TextContent(type="text", text=f"Error: {err}")]
         # Auto-promote explicit project hint to active. Previously the hint only
         # resolved for the current call, forcing agents to either repeat the
         # project= arg on every call or prefix a switch_project. This makes the
         # first real tool call implicitly set the session's active project.
-        if project_hint and slot is not None and s._slot_mgr.active_root != slot.root:
+        # TS_STICKY_ACTIVE freezes the promotion: with parallel agents in
+        # sibling worktrees, one agent's hint must not repoint everyone
+        # else's hint-less calls.
+        if (project_hint and slot is not None
+                and s._slot_mgr.active_root != slot.root
+                and not s._STICKY_ACTIVE):
             s._slot_mgr.active_root = slot.root
 
         handler = _SLOT_HANDLERS.get(name)

--- a/src/token_savior/server_runtime.py
+++ b/src/token_savior/server_runtime.py
@@ -282,6 +282,51 @@ def _parse_workspace_roots() -> list[str]:
     return []
 
 
+def _is_linked_worktree(root: str) -> bool:
+    """A linked git worktree carries a `.git` FILE (gitfile pointer), the main
+    checkout a `.git` directory. The distinction is the routing signal: the
+    file says "this tree is a sibling copy, not the project's home"."""
+    try:
+        return os.path.isfile(os.path.join(root, ".git"))
+    except OSError:
+        return False
+
+
+# Which env variable chose the boot-time active project. "CLAUDE_PROJECT_ROOT"
+# means a human (or wrapper) chose deliberately — nothing else may override.
+_active_hint_source = ""
+
+
+def _boot_env_root_hint() -> tuple[str, str]:
+    """(path, variable) of the environment's project hint, or ("", "").
+
+    Two variables, in order of deliberateness — verified against the hosts,
+    not their folklore:
+
+    - CLAUDE_PROJECT_ROOT: Token Savior's own contract. NO host sets it
+      (it appears nowhere in the Claude Code docs), so when present a human
+      or wrapper script chose it — top priority.
+    - CLAUDE_PROJECT_DIR: what Claude Code actually exports to stdio MCP
+      servers. Stable by design: always the main checkout, never the
+      worktree the session may be working in (code.claude.com/docs/en/mcp).
+    - Codex exports no path variable at all AND whitelist-filters the MCP
+      server environment, so under Codex both are absent and the spawn cwd
+      (which Codex does point at the workspace) carries the signal instead.
+
+    A candidate only counts if it exists and looks like a project (marker
+    file; a `.git` file — a linked worktree — counts). With both variables
+    set, the one that validates wins.
+    """
+    for var in ("CLAUDE_PROJECT_ROOT", "CLAUDE_PROJECT_DIR"):
+        raw = os.environ.get(var, "").strip()
+        if not raw:
+            continue
+        cand = os.path.abspath(raw)
+        if cand in s._slot_mgr.projects or (os.path.isdir(cand) and is_project_dir(cand)):
+            return cand, var
+    return "", ""
+
+
 def _register_roots(roots: list[str]) -> None:
     """Create slots for each root. Index is built lazily on first use.
 
@@ -291,16 +336,27 @@ def _register_roots(roots: list[str]) -> None:
     exactly what happened: two unrelated memory-viewer tests started failing.
     Discovery belongs to `autodiscover_and_register`, called from `main()`.
 
-    Honors CLAUDE_PROJECT_ROOT env: if set and the path is one of the
-    registered roots, promote it to active. This lets short-lived subprocess
-    callers (benchmarks, `claude -p`, scripted flows) skip switch_project
-    entirely when the calling shell already knows which project is in focus.
+    Honors the environment's project hint (see _boot_env_root_hint): a valid
+    hint is registered if needed and promoted to active. This lets short-lived
+    subprocess callers (benchmarks, `claude -p`, scripted flows) skip
+    switch_project entirely when the calling environment already knows which
+    project is in focus.
     """
+    global _active_hint_source
     s._slot_mgr.register_roots(roots)
-    hint = os.environ.get("CLAUDE_PROJECT_ROOT", "").strip()
-    hint_abs = os.path.abspath(hint) if hint else ""
-    if hint_abs and hint_abs in s._slot_mgr.projects:
-        s._slot_mgr.active_root = hint_abs
+    hint_abs, hint_src = _boot_env_root_hint()
+    if hint_abs:
+        # Only the deliberate variable may REGISTER a root here: this runs at
+        # import time, and CLAUDE_PROJECT_DIR is set for every child process
+        # of a Claude Code session — pytest included. Letting it register
+        # would make every test run adopt the developer's own repo. The
+        # automatic variable therefore only promotes among roots that
+        # explicit config or discovery already registered.
+        if hint_abs not in s._slot_mgr.projects and hint_src == "CLAUDE_PROJECT_ROOT":
+            s._slot_mgr.register_roots([hint_abs])
+        if hint_abs in s._slot_mgr.projects:
+            s._slot_mgr.active_root = hint_abs
+            _active_hint_source = hint_src
 
     if os.environ.get("TS_WARM_START", "").strip() in ("1", "true", "yes"):
         targets = [hint_abs] if hint_abs in s._slot_mgr.projects else list(s._slot_mgr.projects)
@@ -324,19 +380,46 @@ def autodiscover_and_register() -> list[str]:
     Called from `main()` rather than at import, so unit tests never trigger it.
     Set `TOKEN_SAVIOR_AUTODISCOVER=0` to keep the old behaviour.
     """
-    if s._slot_mgr.projects:
-        return []
     if os.environ.get("TOKEN_SAVIOR_AUTODISCOVER", "1") == "0":
         return []
-    roots = autodiscover_roots()
-    if not roots:
-        return []
-    _register_roots(roots)
-    print(f"[token-savior] auto-discovered {len(roots)} project(s): "
-          f"{', '.join(os.path.basename(r) for r in roots[:5])}"
-          f"{'...' if len(roots) > 5 else ''}. "
-          f"Set WORKSPACE_ROOTS to pin them explicitly.", file=sys.stderr)
-    return roots
+
+    fresh: list[str] = []
+    if not s._slot_mgr.projects:
+        roots = autodiscover_roots()
+        if roots:
+            _register_roots(roots)
+            fresh = roots
+            print(f"[token-savior] auto-discovered {len(roots)} project(s): "
+                  f"{', '.join(os.path.basename(r) for r in roots[:5])}"
+                  f"{'...' if len(roots) > 5 else ''}. "
+                  f"Set WORKSPACE_ROOTS to pin them explicitly.", file=sys.stderr)
+
+    # The directory the server was actually started in always gets a slot,
+    # even when WORKSPACE_ROOTS pinned the registry. A session launched
+    # inside a linked worktree of a configured repo otherwise routed every
+    # call to the parent checkout — the worktree was never registered at all.
+    cwd_root = project_root_of(os.getcwd())
+    if cwd_root and cwd_root not in s._slot_mgr.projects:
+        s._slot_mgr.register_roots([cwd_root])
+        fresh.append(cwd_root)
+        print(f"[token-savior] registered launch-directory project: {cwd_root}",
+              file=sys.stderr)
+
+    # A cwd that is a linked worktree outranks the environment's stable hint:
+    # CLAUDE_PROJECT_DIR deliberately pins the MAIN checkout even when the
+    # session works in a worktree (that is its documented contract), and the
+    # spawn cwd is the only signal that follows the worktree. Only an
+    # explicit CLAUDE_PROJECT_ROOT — set by a human, never by a host — wins
+    # over it.
+    if (cwd_root and cwd_root in s._slot_mgr.projects
+            and s._slot_mgr.active_root != cwd_root
+            and _is_linked_worktree(cwd_root)
+            and _active_hint_source != "CLAUDE_PROJECT_ROOT"):
+        s._slot_mgr.active_root = cwd_root
+        print(f"[token-savior] active project follows the launch worktree: "
+              f"{cwd_root}", file=sys.stderr)
+
+    return fresh
 
 
 _client_roots_synced = False

--- a/src/token_savior/server_state.py
+++ b/src/token_savior/server_state.py
@@ -264,3 +264,12 @@ _CHAIN_NUDGE_DISABLED: bool = (
 _TS_SEARCH_COLD_DELEGATE: bool = (
     os.environ.get("TS_SEARCH_COLD_DELEGATE", "0").lower() in ("1", "true", "on")
 )
+
+# Opt-in for parallel multi-agent sessions (several worktrees, one server or
+# daemon): freeze active_root. Explicit `project` hints and absolute-path
+# arguments still route each call correctly; what stops is one agent's hint
+# silently repointing the shared default that every hint-less call falls
+# back to.
+_STICKY_ACTIVE: bool = (
+    os.environ.get("TS_STICKY_ACTIVE", "0").lower() in ("1", "true", "on")
+)

--- a/src/token_savior/slot_manager.py
+++ b/src/token_savior/slot_manager.py
@@ -321,12 +321,42 @@ class SlotManager:
             file=sys.stderr,
         )
 
+    def resolve_path(self, path: str) -> _ProjectSlot | None:
+        """Route an absolute filesystem path to the project that OWNS it.
+
+        Nearest marker root wins, so a path inside a worktree nested in a
+        registered repo (`repo/.claude/worktrees/wt/src/x.py`) routes to the
+        worktree slot — a linked worktree carries a `.git` *file*, which
+        counts as a marker — never to the parent checkout that happens to
+        contain it. An unregistered root is registered on the spot.
+
+        Deliberately does NOT touch ``active_root``: this is the per-call
+        routing signal parallel agents (several worktrees, one server) rely
+        on, and mutating the shared default from one agent's call is exactly
+        the race this method exists to avoid.
+        """
+        if not path or not os.path.isabs(path):
+            return None
+        # Lazy import: server_runtime pulls in server_state, which imports
+        # this module — a top-level import would be circular.
+        from token_savior.server_runtime import project_root_of
+        root = project_root_of(path)
+        if not root:
+            return None
+        if root not in self.projects:
+            try:
+                self.register_roots([root])
+            except Exception:
+                return None
+        return self.projects.get(root)
+
     def resolve(self, project_hint: str | None = None) -> tuple[_ProjectSlot | None, str]:
         """
         Return (slot, error_message). error_message is empty on success.
 
         Resolution order:
-        1. explicit project_hint (basename or full path)
+        1. explicit project_hint (full path — routed to the project that
+           owns it, nearest marker root first, worktree-aware — or basename)
         2. active_root
         3. only registered project (if exactly one)
         4. error
@@ -336,6 +366,14 @@ class SlotManager:
             hint_abs = os.path.abspath(project_hint)
             if hint_abs in self.projects:
                 return self.projects[hint_abs], ""
+            # Path-like hint: route to the OWNING project before any name
+            # fuzzing. `repo/.claude/worktrees/wt` must reach the worktree
+            # slot, and a subdirectory of a registered project must resolve
+            # to that project — not get registered as a project of its own.
+            if os.sep in project_hint:
+                slot = self.resolve_path(hint_abs)
+                if slot is not None:
+                    return slot, ""
             # Try basename match
             for root, slot in self.projects.items():
                 if os.path.basename(root) == project_hint:
@@ -370,33 +408,14 @@ class SlotManager:
                     return reverse[0][1], ""
             # Un chemin reel que personne n'a enregistre : le refuser envoyait
             # vers set_project_root sans raison. On sait ou il est, il existe.
+            # resolve_path d'abord : si le dossier appartient a un projet (ou
+            # est un worktree), c'est SA racine qu'on enregistre, pas le
+            # sous-dossier. Sans marqueur nulle part, on enregistre tel quel.
             if os.path.isdir(hint_abs):
-                try:
-                    self.register_roots([*self.projects, hint_abs])
-                    if hint_abs in self.projects:
-                        self.active_root = hint_abs
-                        return self.projects[hint_abs], ""
-                except Exception:
-                    pass
-            # Reverse containment: the hint is *longer* than the project name.
-            # Measured on real calls: `scribe-transcription` never matched the
-            # registered `scribe`, because only hint-inside-basename was tried.
-            # Longest basename wins, so `api` never beats `api-client`.
-            reverse = [
-                (root, slot) for root, slot in self.projects.items()
-                if os.path.basename(root).lower() in hint_lower
-                and len(os.path.basename(root)) >= 4
-            ]
-            if reverse:
-                reverse.sort(key=lambda rs: len(os.path.basename(rs[0])), reverse=True)
-                best = os.path.basename(reverse[0][0]).lower()
-                if len({os.path.basename(r).lower() for r, _ in reverse
-                        if len(os.path.basename(r).lower()) == len(best)}) == 1:
-                    return reverse[0][1], ""
-            # The hint names a real directory nobody registered yet. Refusing
-            # here sent the caller to set_project_root for no reason: we know
-            # the path, it exists, and registering is what they wanted.
-            if os.path.isdir(hint_abs):
+                slot = self.resolve_path(hint_abs)
+                if slot is not None:
+                    self.active_root = slot.root
+                    return slot, ""
                 try:
                     self.register_roots([*self.projects, hint_abs])
                     if hint_abs in self.projects:

--- a/tests/test_arg_aliases_and_resolution.py
+++ b/tests/test_arg_aliases_and_resolution.py
@@ -16,6 +16,8 @@ un chemin reel non enregistre etait refuse alors qu'on savait quoi faire.
 """
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from token_savior.server import _normalize_arguments
@@ -115,6 +117,71 @@ def test_un_chemin_inexistant_reste_une_erreur_utile(tmp_path) -> None:
     _, err = m.resolve("/chemin/qui/n/existe/pas")
     assert "not found" in err
     assert "connu" in err, "l'erreur doit lister ce qui existe"
+
+
+# --- Routage par argument de chemin (agents paralleles, worktrees) --------- #
+#
+# Plusieurs agents, un seul serveur, active_root partage : le seul signal
+# par appel qui ne se fait pas voler est un chemin ABSOLU dans les arguments.
+# Il route l'appel vers l'arbre qui le possede (racine a marqueur la plus
+# proche : un worktree imbrique gagne sur le checkout parent) sans jamais
+# toucher au defaut partage.
+
+def _depot_avec_worktree(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / ".git").mkdir()
+    wt = repo / ".claude" / "worktrees" / "fix-98"
+    (wt / "src").mkdir(parents=True)
+    (wt / ".git").write_text("gitdir: ../../../.git/worktrees/fix-98\n")
+    return str(repo), str(wt)
+
+
+def test_implicit_project_path_ne_lit_que_l_absolu() -> None:
+    from token_savior.server import _implicit_project_path
+
+    assert _implicit_project_path({"file_path": "/abs/x.py"}) == "/abs/x.py"
+    assert _implicit_project_path({"path": "/abs/y"}) == "/abs/y"
+    assert _implicit_project_path({"file_path": "rel/x.py"}) is None
+    assert _implicit_project_path({"name": "foo"}) is None
+
+
+def test_un_chemin_absolu_route_l_appel_sans_toucher_l_actif(tmp_path, monkeypatch) -> None:
+    import token_savior.server as srv
+    from token_savior import server_state as s
+
+    repo, wt = _depot_avec_worktree(tmp_path)
+    m = SlotManager(cache_version=1)
+    m.register_roots([repo])
+    m.active_root = repo
+    monkeypatch.setattr(s, "_slot_mgr", m)
+
+    srv._dispatch_tool("get_git_status", {"file_path": os.path.join(wt, "src", "x.py")}, "")
+
+    assert wt in m.projects, "le worktree du chemin doit obtenir son slot"
+    assert m.active_root == repo, (
+        "le routage implicite ne doit jamais deplacer le defaut partage : "
+        "c'est la course entre agents paralleles"
+    )
+
+
+def test_ts_sticky_active_gele_la_promotion(tmp_path, monkeypatch) -> None:
+    import token_savior.server as srv
+    from token_savior import server_state as s
+
+    repo, wt = _depot_avec_worktree(tmp_path)
+    m = SlotManager(cache_version=1)
+    m.register_roots([repo, wt])
+    m.active_root = repo
+    monkeypatch.setattr(s, "_slot_mgr", m)
+
+    monkeypatch.setattr(s, "_STICKY_ACTIVE", True)
+    srv._dispatch_tool("get_git_status", {"project": wt}, "")
+    assert m.active_root == repo, "hint explicite servi, mais defaut partage gele"
+
+    monkeypatch.setattr(s, "_STICKY_ACTIVE", False)
+    srv._dispatch_tool("get_git_status", {"project": wt}, "")
+    assert m.active_root == wt, "sans le gel, la promotion historique demeure"
 
 
 def test_l_ambiguite_reste_refusee(tmp_path) -> None:

--- a/tests/test_autodiscover_roots.py
+++ b/tests/test_autodiscover_roots.py
@@ -180,3 +180,135 @@ def test_le_demarrage_se_debraye(tmp_path, monkeypatch) -> None:
     rt.s._slot_mgr.projects.clear()
     assert rt.autodiscover_and_register() == []
     assert recus == []
+
+
+# --- indications d'environnement (CLAUDE_PROJECT_ROOT / CLAUDE_PROJECT_DIR) - #
+#
+# Verifie contre les hotes, pas leur folklore : Claude Code exporte
+# CLAUDE_PROJECT_DIR (stable, toujours le checkout principal, jamais le
+# worktree — code.claude.com/docs/en/mcp) ; CLAUDE_PROJECT_ROOT n'est
+# documente nulle part, c'est NOTRE contrat, donc s'il est present un humain
+# l'a choisi. Codex n'exporte aucune variable de chemin et filtre l'env des
+# serveurs MCP par liste blanche : seul le cwd de lancement porte le signal.
+
+def _mgr_vierge(monkeypatch, rt):
+    from token_savior.slot_manager import SlotManager
+
+    mgr = SlotManager(cache_version=2)
+    monkeypatch.setattr(rt.s, "_slot_mgr", mgr)
+    monkeypatch.setattr(rt, "_active_hint_source", "")
+    monkeypatch.delenv("CLAUDE_PROJECT_ROOT", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("TOKEN_SAVIOR_AUTODISCOVER", raising=False)
+    monkeypatch.delenv("TS_WARM_START", raising=False)
+    return mgr
+
+
+def _worktree_imbrique(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / ".git").mkdir()
+    wt = repo / ".claude" / "worktrees" / "fix-98"
+    wt.mkdir(parents=True)
+    (wt / ".git").write_text("gitdir: ../../../.git/worktrees/fix-98\n")
+    return repo, wt
+
+
+def test_un_worktree_lie_est_un_projet(tmp_path) -> None:
+    """Un worktree lie porte un fichier `.git`, pas un dossier : il doit
+    compter comme marqueur, sinon rien ne s'arrete a sa racine."""
+    _repo, wt = _worktree_imbrique(tmp_path)
+    assert is_project_dir(str(wt))
+    assert project_root_of(str(wt)) == str(wt)
+
+
+def test_claude_project_dir_promeut_sans_jamais_enregistrer(tmp_path, monkeypatch) -> None:
+    import token_savior.server_runtime as rt
+
+    mgr = _mgr_vierge(monkeypatch, rt)
+    a = make_project(tmp_path, "a")
+    b = make_project(tmp_path, "b")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(b))
+    rt._register_roots([str(a), str(b)])
+    assert mgr.active_root == str(b)
+
+    # Non enregistre : promotion refusee, et surtout PAS d'enregistrement —
+    # cette variable est posee par l'hote pour chaque process enfant, pytest
+    # compris ; l'honorer a l'import ferait adopter le depot du developpeur
+    # a chaque run de tests.
+    mgr2 = _mgr_vierge(monkeypatch, rt)
+    c = make_project(tmp_path, "c")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(c))
+    rt._register_roots([])
+    assert mgr2.projects == {}
+    assert mgr2.active_root == ""
+
+
+def test_claude_project_root_delibere_enregistre_et_gagne(tmp_path, monkeypatch) -> None:
+    import token_savior.server_runtime as rt
+
+    mgr = _mgr_vierge(monkeypatch, rt)
+    a = make_project(tmp_path, "a")
+    b = make_project(tmp_path, "b")
+    monkeypatch.setenv("CLAUDE_PROJECT_ROOT", str(a))
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(b))
+    rt._register_roots([str(b)])
+    assert str(a) in mgr.projects, "le contrat delibere peut enregistrer"
+    assert mgr.active_root == str(a), "ROOT (humain) l'emporte sur DIR (hote)"
+
+
+def test_variable_invalide_cede_a_celle_qui_valide(tmp_path, monkeypatch) -> None:
+    """Les deux posees : celle qui pointe un vrai projet (marqueur) gagne."""
+    import token_savior.server_runtime as rt
+
+    mgr = _mgr_vierge(monkeypatch, rt)
+    sans_marqueur = tmp_path / "pas-un-projet"
+    sans_marqueur.mkdir()
+    b = make_project(tmp_path, "b")
+    monkeypatch.setenv("CLAUDE_PROJECT_ROOT", str(sans_marqueur))
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(b))
+    rt._register_roots([str(b)])
+    assert mgr.active_root == str(b)
+
+
+def test_le_cwd_est_toujours_enregistre_meme_configure(tmp_path, monkeypatch) -> None:
+    """WORKSPACE_ROOTS fige le registre, mais le dossier de lancement doit
+    quand meme avoir un slot : une session demarree dans un worktree d'un
+    depot configure routait sinon tous ses appels vers le checkout parent."""
+    import token_savior.server_runtime as rt
+
+    mgr = _mgr_vierge(monkeypatch, rt)
+    repo, wt = _worktree_imbrique(tmp_path)
+    mgr.register_roots([str(repo)])
+    monkeypatch.chdir(wt)
+    rt.autodiscover_and_register()
+    assert str(wt) in mgr.projects
+
+
+def test_le_worktree_de_lancement_devient_actif(tmp_path, monkeypatch) -> None:
+    """CLAUDE_PROJECT_DIR epingle volontairement le checkout PRINCIPAL, meme
+    quand la session travaille dans un worktree (contrat documente). Le cwd
+    est le seul signal qui suit le worktree : il doit l'emporter."""
+    import token_savior.server_runtime as rt
+
+    mgr = _mgr_vierge(monkeypatch, rt)
+    repo, wt = _worktree_imbrique(tmp_path)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+    rt._register_roots([str(repo)])
+    assert mgr.active_root == str(repo)
+    monkeypatch.chdir(wt)
+    rt.autodiscover_and_register()
+    assert mgr.active_root == str(wt)
+
+
+def test_root_delibere_l_emporte_sur_le_worktree_de_lancement(tmp_path, monkeypatch) -> None:
+    import token_savior.server_runtime as rt
+
+    mgr = _mgr_vierge(monkeypatch, rt)
+    repo, wt = _worktree_imbrique(tmp_path)
+    monkeypatch.setenv("CLAUDE_PROJECT_ROOT", str(repo))
+    rt._register_roots([str(repo)])
+    monkeypatch.chdir(wt)
+    rt.autodiscover_and_register()
+    assert str(wt) in mgr.projects, "le worktree garde son slot"
+    assert mgr.active_root == str(repo), "un choix humain explicite n'est pas renverse"

--- a/tests/test_slot_manager.py
+++ b/tests/test_slot_manager.py
@@ -76,6 +76,102 @@ class TestResolve:
         assert "Multiple projects" in err
 
 
+def _repo_with_nested_worktree(tmp_path):
+    """A main checkout plus a linked worktree nested inside it, the way
+    Claude Code lays them out (`repo/.claude/worktrees/<branch>`). The
+    worktree carries a `.git` FILE (gitfile pointer), the main checkout a
+    `.git` directory — that difference is what the routing relies on."""
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / ".git").mkdir()
+    wt = repo / ".claude" / "worktrees" / "fix-98"
+    (wt / "src").mkdir(parents=True)
+    (wt / ".git").write_text("gitdir: ../../../.git/worktrees/fix-98\n")
+    return str(repo), str(wt)
+
+
+class TestResolvePath:
+    """Per-call routing of absolute paths — the signal parallel agents in
+    sibling worktrees rely on, since they share one server and one
+    active_root."""
+
+    def test_nested_worktree_wins_over_parent(self, tmp_path):
+        repo, wt = _repo_with_nested_worktree(tmp_path)
+        mgr = SlotManager(cache_version=2)
+        mgr.register_roots([repo])
+        slot = mgr.resolve_path(os.path.join(wt, "src", "mod.py"))
+        assert slot is not None
+        assert slot.root == wt, "path inside the worktree must reach the worktree slot"
+        assert wt in mgr.projects, "unregistered worktree root registers on the fly"
+
+    def test_path_inside_parent_resolves_parent(self, tmp_path):
+        repo, _wt = _repo_with_nested_worktree(tmp_path)
+        mgr = SlotManager(cache_version=2)
+        mgr.register_roots([repo])
+        slot = mgr.resolve_path(os.path.join(repo, "src", "mod.py"))
+        assert slot is not None and slot.root == repo
+        assert list(mgr.projects) == [repo], "no spurious registration for in-tree paths"
+
+    def test_does_not_touch_active_root(self, tmp_path):
+        repo, wt = _repo_with_nested_worktree(tmp_path)
+        mgr = SlotManager(cache_version=2)
+        mgr.register_roots([repo])
+        mgr.active_root = repo
+        mgr.resolve_path(os.path.join(wt, "src", "mod.py"))
+        assert mgr.active_root == repo, (
+            "implicit path routing must never mutate the shared default — "
+            "that is the race between parallel agents"
+        )
+
+    def test_relative_path_is_no_signal(self, tmp_path):
+        mgr = SlotManager(cache_version=2)
+        mgr.register_roots([str(tmp_path)])
+        assert mgr.resolve_path("src/mod.py") is None
+
+    def test_path_outside_any_project(self, tmp_path):
+        mgr = SlotManager(cache_version=2)
+        bare = tmp_path / "no-marker" / "deep"
+        bare.mkdir(parents=True)
+        assert mgr.resolve_path(str(bare / "f.py")) is None
+
+
+class TestResolvePathHints:
+    """resolve() with a path-like hint routes to the OWNING project."""
+
+    def test_worktree_path_hint_resolves_worktree(self, tmp_path):
+        repo, wt = _repo_with_nested_worktree(tmp_path)
+        mgr = SlotManager(cache_version=2)
+        mgr.register_roots([repo])
+        slot, err = mgr.resolve(os.path.join(wt, "src"))
+        assert err == ""
+        assert slot.root == wt
+
+    def test_subdir_hint_resolves_owner_not_itself(self, tmp_path):
+        """Before: a real-but-unregistered subdirectory got registered as a
+        project of its own. Now it routes to the project that owns it."""
+        repo, _wt = _repo_with_nested_worktree(tmp_path)
+        mgr = SlotManager(cache_version=2)
+        mgr.register_roots([repo])
+        sub = os.path.join(repo, "src")
+        slot, err = mgr.resolve(sub)
+        assert err == ""
+        assert slot.root == repo
+        assert sub not in mgr.projects
+
+    def test_markerless_dir_hint_still_registers_as_before(self, tmp_path):
+        """A directory with no marker anywhere up the tree keeps the old
+        contract: register it as given."""
+        mgr = SlotManager(cache_version=2)
+        other = str(tmp_path / "proj-registered")
+        os.makedirs(other)
+        mgr.projects[other] = _ProjectSlot(root=other)
+        bare = tmp_path / "pile-of-files"
+        bare.mkdir()
+        slot, err = mgr.resolve(str(bare))
+        assert err == ""
+        assert slot.root == str(bare)
+
+
 class TestEnsure:
     """Tests for SlotManager.ensure()."""
 


### PR DESCRIPTION
Multiple agents working in sibling worktrees share one server (or `ts` daemon) and one mutable `active_root`; the worktree a session actually works in was often never registered at all, so edits landed in the parent checkout. Follow-up to the discussion in #98 about the single-socket/multi-repo architecture.

Verified against the hosts rather than assumed:

- Claude Code exports `CLAUDE_PROJECT_DIR` (stable — always the main checkout, never the worktree; code.claude.com/docs/en/mcp). `CLAUDE_PROJECT_ROOT`, which the server and the memory hooks read, is set by **no** host — the session-start hook ran with an empty project.
- Codex exports no path variable and whitelist-filters the MCP server environment (openai/codex `rmcp-client/src/utils.rs`), so only the spawn cwd carries its signal — and `WORKSPACE_ROOTS` exported in a shell never reaches a Codex-spawned server.

## Changes

- **`SlotManager.resolve_path`** — per-call routing: an absolute `file_path`/`path`/`target_file` (or a path-like `project` hint) resolves to the nearest marker root, so a worktree nested in a registered repo (`repo/.claude/worktrees/wt`, `.git` *file* counts as a marker) wins over the parent checkout containing it; the owning root registers on the fly and `active_root` is never touched.
- Path hints resolve to their **owning** project — a subdirectory no longer registers as a project of its own; removed a literally duplicated reverse-containment/register block in `resolve()`.
- Boot signals validated by marker, then ranked: `CLAUDE_PROJECT_ROOT` (deliberate; may register, always wins) → launch-cwd root (the only worktree-following and only Codex-available signal; a linked worktree takes active) → `CLAUDE_PROJECT_DIR` (promotes among registered roots, never registers — otherwise pytest under Claude Code adopts the developer's repo at import). The launch directory always gets a slot even when `WORKSPACE_ROOTS` pins the registry.
- **`TS_STICKY_ACTIVE=1`** freezes active-root promotion for multi-agent sessions.
- Hooks and the standalone CLI fall back `CLAUDE_PROJECT_ROOT` → `CLAUDE_PROJECT_DIR` → `$PWD`.
- 16 new tests; docs for the env cascade and the Codex whitelist trap.

## Testing

Full suite: 2825 passed, 61 skipped; the 4 failures on this container (`test_polyglot_class_ambiguity`, `test_vector_distance_floor`) predate the change and reproduce identically on the parent commit (missing Ruby tree-sitter grammar / embedding model in the test environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRJszm2vmSMKFUBZEnajwm