### PR TITLE
feat: query-aware, lossless trimming (get_full_context intent + capture relevant:)

### DIFF
--- a/src/token_savior/memory/tool_capture.py
+++ b/src/token_savior/memory/tool_capture.py
@@ -220,6 +220,26 @@ def capture_search(
 _PLAGE_LIGNES = re.compile(r"(\d+)\s*-\s*(\d+)")
 
 
+def _select_relevant_lines(text: str, query: str, max_lines: int = 40) -> tuple[str, int]:
+    """Query-aware slice of a captured output: keep the lines most relevant to
+    `query` (deterministic lexical scoring, no model), in original order.
+    Returns (joined_lines, omitted_count). Lossless: full stays via range='all'.
+    """
+    lines = text.splitlines()
+    total = len(lines)
+    terms = [t for t in re.findall(r"[a-z0-9]+", query.lower()) if len(t) > 2]
+    if not terms or total <= max_lines:
+        return text, 0
+    scored = [(sum(1 for t in terms if t in ln.lower()), i) for i, ln in enumerate(lines)]
+    matched = [(s, i) for s, i in scored if s > 0]
+    if not matched:
+        head = lines[:max_lines]
+        return "\n".join(head), total - len(head)
+    matched.sort(key=lambda x: (-x[0], x[1]))
+    keep_idx = sorted(i for _, i in matched[:max_lines])
+    return "\n".join(lines[i] for i in keep_idx), total - len(keep_idx)
+
+
 def capture_get(
     cap_id: int,
     *,
@@ -229,7 +249,9 @@ def capture_get(
     """Retrieve a captured output, optionally sliced.
 
     range_spec accepts: 'head', 'tail', 'all', 'preview', 'line:start-end'
-    (1-indexed inclusive). Defaults to 'preview' for safety.
+    (1-indexed inclusive), or 'relevant:<query>' — the lines most relevant to a
+    question (deterministic, no model, lossless: the full text stays reachable
+    via 'all'). Defaults to 'preview' for safety.
     max_bytes caps the returned content slice.
     """
     spec = (range_spec or "preview").strip().lower()
@@ -259,6 +281,14 @@ def capture_get(
         content = "\n".join(full.splitlines()[-50:])
     elif spec == "all":
         content = full
+    elif spec.startswith(("relevant:", "intent:")):
+        # Query-aware slice of an arbitrary captured output (logs, JSON, docs):
+        # keep the lines that match the question, drop the rest, point to 'all'.
+        # This is where the non-code 80% saves — lossless, deterministic.
+        query = spec.split(":", 1)[1].strip()
+        content, omitted = _select_relevant_lines(full, query)
+        if omitted:
+            content += f"\n# +{omitted} less-relevant lines omitted (range='all' for full)"
     elif _PLAGE_LIGNES.fullmatch(spec):
         # `10-12` est accepte au meme titre que `line:10-12`. Un appelant qui
         # ecrit la forme naturelle recevait auparavant le contenu ENTIER, sans
@@ -275,6 +305,7 @@ def capture_get(
             "uri": f"ts://capture/{cap_id}",
             "error": (f"range '{range_spec}' non reconnu. Formes acceptees : "
                       "'preview' (defaut), 'head', 'tail', 'all', "
+                      "'relevant:<question>', "
                       "'line:<debut>-<fin>' ou '<debut>-<fin>' (1-indexe, "
                       "bornes incluses)."),
             "output_lines": row["output_lines"],

--- a/src/token_savior/server_handlers/code_nav.py
+++ b/src/token_savior/server_handlers/code_nav.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from typing import Any
 
 from token_savior import memory_db
@@ -626,12 +627,40 @@ def _q_get_full_context(qfns, args: dict[str, Any]):
     )
     mode = args.get("mode", "compact")
     if mode == "compact" and isinstance(result, dict):
-        return _compact_full_context(result)
+        return _compact_full_context(result, args.get("intent"))
     return result
 
 
-def _compact_full_context(result: dict) -> dict:
-    """Trim heavy fields: deps/dependents → names only, source → head 80 lines."""
+_INTENT_KEEP = 12
+
+
+def _rank_by_intent(names: list[str], intent: str, keep: int) -> tuple[list[str], int]:
+    """Deterministic lexical relevance rank (no model): count intent terms that
+    hit each name by token match or substring. Stable — earlier items win ties.
+    Returns (kept_names, dropped_count)."""
+    terms = [t for t in re.findall(r"[a-z0-9]+", intent.lower()) if len(t) > 2]
+    if not terms:
+        return names[:keep], max(0, len(names) - keep)
+
+    def _score(item):
+        i, n = item
+        low = n.lower()
+        toks = set(re.findall(r"[a-z0-9]+", low))
+        overlap = sum(1 for t in terms if t in toks)
+        substr = sum(1 for t in terms if t in low)
+        return (overlap, substr, -i)
+
+    ranked = sorted(enumerate(names), key=_score, reverse=True)
+    return [n for _, n in ranked[:keep]], max(0, len(names) - keep)
+
+
+def _compact_full_context(result: dict, intent: str | None = None) -> dict:
+    """Trim heavy fields: deps/dependents -> names only, source -> head 80 lines.
+
+    When `intent` is set, long deps/dependents lists are ranked by lexical
+    relevance to it and trimmed to the top _INTENT_KEEP, with a recovery
+    pointer appended -- lossless (the rest stays reachable via mode='full').
+    """
     compact: dict[str, Any] = {}
     for key in ("name", "file", "line", "type", "signature", "error", "symbol"):
         if key in result:
@@ -646,10 +675,16 @@ def _compact_full_context(result: dict) -> dict:
     for key in ("dependencies", "dependents", "callers", "callees", "change_impact"):
         val = result.get(key)
         if isinstance(val, list):
-            compact[key] = [
+            names = [
                 item.get("name") if isinstance(item, dict) else item
                 for item in val
             ]
+            clean = [n for n in names if n]
+            if intent and len(clean) > _INTENT_KEEP:
+                kept, dropped = _rank_by_intent(clean, intent, _INTENT_KEEP)
+                compact[key] = kept + [f"# +{dropped} ranked out by intent (mode='full' to expand)"]
+            else:
+                compact[key] = names
         elif val is not None:
             compact[key] = val
     return compact

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -465,6 +465,10 @@ TOOL_SCHEMAS: dict[str, dict] = {
                     "enum": ["compact", "full"],
                     "description": "compact (default): source head 80 lines + deps/dependents as names only. full: raw payload.",
                 },
+                "intent": {
+                    "type": "string",
+                    "description": "Optional task/query. When set, long deps/dependents lists are ranked by relevance to it and trimmed to the top few with a recovery pointer — lossless (the rest stays reachable via mode='full').",
+                },
                 **_PROJECT_PARAM,
             },
         },

--- a/src/token_savior/tool_schemas.py
+++ b/src/token_savior/tool_schemas.py
@@ -1169,7 +1169,7 @@ TOOL_SCHEMAS: dict[str, dict] = {
             "required": ["id"],
             "properties": {
                 "id": {"type": "integer", "description": "Capture id (from search/list)."},
-                "range": {"type": "string", "description": "head | tail | all | preview | line:start-end (default preview)."},
+                "range": {"type": "string", "description": "head | tail | all | preview | line:start-end | relevant:<question> (keeps only the lines relevant to the question, lossless — 'all' still returns everything). Default preview."},
                 "max_bytes": {"type": "integer", "description": "Cap returned content size."},
             },
         },

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -1740,3 +1740,30 @@ class TestCompressChangeImpact:
         assert "@S:A.run" in out and "@L:10" in out
         assert "## transitive" in out
         assert "@S:B.step" in out and "@S:helper" in out
+
+
+def test_get_full_context_intent_trims_and_keeps_pointer():
+    """intent ranks deps by relevance, trims to _INTENT_KEEP + a recovery
+    pointer -- lossless (the rest stays reachable via mode='full')."""
+    from token_savior.server_handlers.code_nav import _INTENT_KEEP, _compact_full_context
+    deps = [{"name": n} for n in
+            ([f"noise_{i}" for i in range(20)] + ["validate_auth_token", "auth_middleware"])]
+    res = {"name": "X", "dependents": deps}
+    out = _compact_full_context(res, intent="how is the auth token validated")
+    kept = out["dependents"]
+    assert len(kept) == _INTENT_KEEP + 1          # trimmed + one pointer line
+    assert any("ranked out" in str(x) for x in kept)
+    assert any("auth_token" in str(x) for x in kept)   # relevant name surfaced
+    # no intent -> unchanged behaviour: all names, no pointer
+    plain = _compact_full_context(res)["dependents"]
+    assert len(plain) == len(deps)
+    assert not any("ranked out" in str(x) for x in plain)
+
+
+def test_rank_by_intent_is_deterministic_and_stable():
+    from token_savior.server_handlers.code_nav import _rank_by_intent
+    names = ["parse", "auth_check", "log", "auth_token", "render"]
+    a, dropped = _rank_by_intent(names, "auth token", keep=2)
+    b, _ = _rank_by_intent(names, "auth token", keep=2)
+    assert a == b                       # deterministic, no model
+    assert "auth_token" in a and dropped == 3

--- a/tests/test_tool_capture.py
+++ b/tests/test_tool_capture.py
@@ -287,3 +287,31 @@ def test_preview_omitted_count_positive_when_marker_shown():
     preview = tool_capture._make_preview(output)
     assert "[-" not in preview
     assert "[24 lines omitted" in preview  # 40 - 2*8
+
+
+def test_capture_get_relevant_selects_matching_lines():
+    """range='relevant:<q>' keeps only query-relevant lines + a lossless
+    pointer — A generalized to arbitrary captured output (#non-code 80%)."""
+    lines = [f"boring log line {i}" for i in range(60)]
+    lines[10] = "ERROR: auth token validation failed for user 42"
+    lines[30] = "auth token refreshed successfully"
+    out = "\n".join(lines)
+    res = tool_capture.capture_put(tool_name="Bash", output=out)
+    got = tool_capture.capture_get(res["id"], range_spec="relevant:auth token validation")
+    c = got["content"]
+    assert "auth token validation failed" in c
+    assert "auth token refreshed" in c
+    assert "less-relevant lines omitted" in c        # lossless recovery pointer
+    assert c.count("boring log line") < 60           # trimmed
+    full = tool_capture.capture_get(res["id"], range_spec="all")["content"]
+    assert full.count("boring log line") == 58       # 'all' still returns everything
+
+
+def test_select_relevant_lines_is_deterministic():
+    from token_savior.memory.tool_capture import _select_relevant_lines
+    text = "\n".join(["alpha", "beta auth", "gamma", "delta auth token", "eps"]
+                      + [f"pad{i}" for i in range(50)])
+    a, om_a = _select_relevant_lines(text, "auth token", max_lines=3)
+    b, om_b = _select_relevant_lines(text, "auth token", max_lines=3)
+    assert a == b and om_a == om_b                   # deterministic, no model
+    assert "delta auth token" in a


### PR DESCRIPTION
Adopts the useful principle from prompt-compression tools (trim to the current query) **without going lossy or model-based** — the trimmed content always stays retrievable. Works across any MCP client (not tied to a harness hook).

**A — get_full_context `intent`.** Optional param: long dependencies/dependents lists are ranked by deterministic lexical relevance to the intent and trimmed to the top 12, with a `# +N ranked out by intent (mode='full' to expand)` pointer. Without `intent`, byte-identical to before.

**Generalized — capture_get `range='relevant:<question>'`.** The same idea applied to arbitrary large tool outputs (logs, JSON, API responses, docs — the non-code majority): keep only the lines matching the question, in original order, with a `+N less-relevant lines omitted (range='all' for full)` pointer. On a 60-line log where 2 lines matter, that's ~2 lines returned vs 60. Full text stays reachable via `range='all'`.

Both use one shared idea: **deterministic lexical relevance, no trained model, lossless recovery pointer.** That keeps Token Savior's edge over lossy prompt-compression: nothing is ever permanently dropped.

Tests: get_full_context intent trim + stable ranking; capture relevant selection + 'all' still returns everything; determinism. ruff clean.