### PR TITLE
feat(B): PreCompact hook prunes superseded context (Claude bonus)

### DIFF
--- a/hooks/memory-precompact.sh
+++ b/hooks/memory-precompact.sh
@@ -62,6 +62,9 @@ if [ -f "$ERR_LOG" ] && [ "$(stat -c%s "$ERR_LOG" 2>/dev/null || echo 0)" -gt 20
     tail -c 1000000 "$ERR_LOG" > "$ERR_LOG.tmp" 2>/dev/null && mv "$ERR_LOG.tmp" "$ERR_LOG"
 fi
 # -- end token-savior hook error log -----------------------------------------
+# PreCompact event payload (stdin). Claude Code pipes the event JSON here; we
+# keep it to extract transcript_path for superseded-context detection (B).
+_TS_PAYLOAD=$(cat)
 RESULT=$($TS_PY -c "
 import sys, os
 sys.path.insert(0, '$TS_SRC')
@@ -124,5 +127,25 @@ if recent:
 
 if [ -n "$RESULT" ]; then
     echo "$RESULT"
+fi
+
+# --- Superseded context (feature B, Claude Code only) ----------------------
+# Flag tool results a later action already invalidated (re-read, read-then-edit,
+# re-run) so compaction can drop them. Read-only, best-effort — never blocks.
+STALE=$(printf '%s' "$_TS_PAYLOAD" | $TS_PY -c "
+import sys, json
+sys.path.insert(0, '$TS_SRC')
+try:
+    tp = (json.load(sys.stdin) or {}).get('transcript_path', '') or ''
+except Exception:
+    tp = ''
+if tp:
+    from token_savior.discover.superseded import precompact_report
+    out = precompact_report(tp)
+    if out:
+        print(out)
+" 2>>"$ERR_LOG")
+if [ -n "$STALE" ]; then
+    echo "$STALE"
 fi
 exit 0

--- a/src/token_savior/discover/superseded.py
+++ b/src/token_savior/discover/superseded.py
@@ -69,3 +69,39 @@ def find_superseded(events: Iterable[Event]) -> list[dict]:
                                      "fresh_index": i})
                 last_bash[key] = i
     return findings
+
+
+def precompact_report(transcript_path: str, max_items: int = 20) -> str:
+    """Markdown section for the PreCompact hook (Claude Code): the stale tool
+    results the summary can safely drop. Empty string when there is nothing to
+    prune or the transcript can't be read. Best-effort — never raises."""
+    try:
+        from pathlib import Path
+
+        from token_savior.discover.transcript_scanner import _iter_session_events
+
+        p = Path(transcript_path)
+        if not p.exists():
+            return ""
+        events = list(_iter_session_events(p, "session", None))
+        stale = find_superseded(events)
+    except Exception:
+        return ""
+    if not stale:
+        return ""
+    label = {
+        "reread": "read again later — keep only the last read",
+        "read_then_edit": "edited after reading — the earlier read is stale",
+        "rerun": "command re-run — the earlier output is stale",
+    }
+    seen: set = set()
+    lines = ["### Superseded context (safe to drop from the summary)"]
+    for f in stale:
+        key = (f["reason"], f["target"])
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(f"- `{f['target']}` — {label.get(f['reason'], f['reason'])}")
+        if len(lines) > max_items:
+            break
+    return "\n".join(lines)

--- a/tests/test_superseded.py
+++ b/tests/test_superseded.py
@@ -61,3 +61,20 @@ def test_fmt_stale_and_handler_smoke():
     assert out[0].type == "text"
     payload = _j.loads(out[0].text)
     assert "stale" in payload and "count" in payload
+
+
+def test_precompact_report_from_transcript(tmp_path):
+    import json
+
+    from token_savior.discover.superseded import precompact_report
+
+    def ev(tool, **inp):
+        return {"type": "assistant", "timestamp": "2026-07-28T00:00:00Z",
+                "message": {"content": [{"type": "tool_use", "name": tool, "input": inp}]}}
+
+    tp = tmp_path / "sess.jsonl"
+    tp.write_text("\n".join(json.dumps(e) for e in
+                            [ev("Read", file_path="a.py"), ev("Read", file_path="a.py")]))
+    md = precompact_report(str(tp))
+    assert "Superseded context" in md and "a.py" in md
+    assert precompact_report(str(tmp_path / "nope.jsonl")) == ""


### PR DESCRIPTION
Completes feature B. `ts_stale_context` (merged in #111) surfaces superseded tool results as advice on any MCP agent; this adds the one place TS can actually **remove** them — the Claude Code PreCompact hook, which runs exactly when the conversation window is rewritten.

- **`precompact_report(transcript_path)`** (in `discover/superseded.py`): reads the session transcript, runs `find_superseded`, returns a compact 'Superseded context (safe to drop from the summary)' markdown section — or '' when there's nothing to prune. Best-effort, never raises.
- **`hooks/memory-precompact.sh`**: captures the PreCompact event payload from stdin, extracts `transcript_path`, appends the section. A stdin capture + one Python call; gated by the same `TS_MEMORY_DISABLE` as the rest of the hook.

Verified end-to-end: a transcript with a re-read of a file yields the section flagging that file. Tested: `precompact_report` from a real transcript file + the empty-on-missing case. ruff clean, bash -n clean.

Honest scope: this is the Claude-only lever (compaction isn't exposed by other harnesses). Cross-agent prevention stays the pointer-returning tools (#110) + the advisory `ts_stale_context` (#111).