### PR TITLE
perf(hints): optimized profile disables per-result hints by default

### DIFF
--- a/src/token_savior/server_handlers/code_nav.py
+++ b/src/token_savior/server_handlers/code_nav.py
@@ -26,7 +26,20 @@ _BATCH_MAX = 10
 # next-step routing advice (the agent must rely on its system prompt).
 # Recommended for benchmark / cold-start workloads where the prompt
 # already encodes routing rules.
-_HINTS_DISABLED = os.environ.get("TS_NO_HINTS") == "1"
+#
+# The `optimized` profile is the token-minimizing default: it already implies
+# thin schemas (server.py), and a usage audit found the per-result hint blocks
+# convert poorly (e.g. the ts_execute nudge fired hundreds of times without
+# moving adoption). So `optimized` disables them too — the ~30-50 tokens/call
+# are a measured overhead there. An explicit TS_NO_HINTS=0 opts back in.
+def _hints_off() -> bool:
+    override = os.environ.get("TS_NO_HINTS")
+    if override is not None:
+        return override == "1"
+    return os.environ.get("TOKEN_SAVIOR_PROFILE", "").lower() == "optimized"
+
+
+_HINTS_DISABLED = _hints_off()
 
 
 def _resolve_batch_names(args: dict[str, Any]) -> list[str] | None:

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -1767,3 +1767,21 @@ def test_rank_by_intent_is_deterministic_and_stable():
     b, _ = _rank_by_intent(names, "auth token", keep=2)
     assert a == b                       # deterministic, no model
     assert "auth_token" in a and dropped == 3
+
+
+def test_hints_off_respects_profile_and_explicit_override(monkeypatch):
+    """optimized profile disables per-result hints by default (measured overhead);
+    an explicit TS_NO_HINTS wins on any profile."""
+    from token_savior.server_handlers.code_nav import _hints_off
+    monkeypatch.delenv("TS_NO_HINTS", raising=False)
+    monkeypatch.setenv("TOKEN_SAVIOR_PROFILE", "optimized")
+    assert _hints_off() is True
+    monkeypatch.setenv("TOKEN_SAVIOR_PROFILE", "full")
+    assert _hints_off() is False
+    # explicit override wins both ways
+    monkeypatch.setenv("TS_NO_HINTS", "0")
+    monkeypatch.setenv("TOKEN_SAVIOR_PROFILE", "optimized")
+    assert _hints_off() is False
+    monkeypatch.setenv("TS_NO_HINTS", "1")
+    monkeypatch.setenv("TOKEN_SAVIOR_PROFILE", "full")
+    assert _hints_off() is True


### PR DESCRIPTION
First of the measured token-overhead removals. A 3-day usage audit (6,785 real calls) showed the per-result hint/suggestion blocks (~30-50 tokens each) fire on most nav results but convert poorly — the ts_execute nudge fired 228 times while adoption stayed 310 vs 4,502 nav calls. On the `optimized` profile (the recommended token-minimizing default, which already thins schemas) they were still on.

`optimized` now disables hints by default, mirroring the thin-schema logic. `TS_NO_HINTS=0` opts back in on any profile; `=1` still forces off; non-optimized profiles are unchanged, so existing hint tests pass untouched.

Remaining (bigger, not rushed): server-side dedup so `get_full_context` omits source already served this session (the measured `read→get_full_context` ×295 waste) — needs careful source-matching between code paths, worth its own pass.