### PR TITLE
perf(context): get_full_context omits source already served this session

### DIFF
--- a/src/token_savior/server_handlers/code_nav.py
+++ b/src/token_savior/server_handlers/code_nav.py
@@ -626,6 +626,43 @@ _LIST_HINTS = [
 ]
 
 
+def _dedup_served_source(result: dict, slot) -> None:
+    """Kill the read->get_full_context re-fetch: if this symbol's source was
+    already served this session (via get_function_source / get_class_source,
+    which populates the CSC session cache) AND its body is unchanged since,
+    omit the source and leave a recovery pointer instead.
+
+    Matches on body_hash, not the source string: the two code paths format
+    source differently, so a string compare would silently never fire. body_hash
+    is the CSC's own unchanged-signal (same `_lookup_symbol_meta` source), so a
+    changed body no longer matches and the source is returned in full.
+    Lossless — the handler runs this in compact mode only; mode='full' bypasses.
+    """
+    name = result.get("name")
+    if not name and isinstance(result.get("symbol"), dict):
+        name = result["symbol"].get("name")
+    src = result.get("source")
+    # Net-positive guard: the pointer is ~90 chars, so on a tiny source the
+    # dedup would cost more than it saves. Same logic as the CSC "only if
+    # shorter" guard.
+    if not name or not isinstance(src, str) or len(src) < 160:
+        return
+    meta = _lookup_symbol_meta(slot, {"name": name})
+    if not meta:
+        return
+    _, cur_body_hash, _ = meta
+    root = getattr(slot, "root", "") or ""
+    for kind in ("function", "class"):
+        entry = state._session_symbol_cache.get(f"{kind}:{root}:{name}")
+        if entry and entry.get("body_hash") == cur_body_hash:
+            result["source"] = (
+                f"# source of {name} already served this session (unchanged) — "
+                "reuse it; call with mode='full' to re-fetch"
+            )
+            state._csc_hits = getattr(state, "_csc_hits", 0) + 1
+            return
+
+
 def _q_get_full_context(qfns, args: dict[str, Any]):
     batch = _batch_dispatch(qfns, args, _q_get_full_context)
     if batch is not None:
@@ -640,6 +677,9 @@ def _q_get_full_context(qfns, args: dict[str, Any]):
     )
     mode = args.get("mode", "compact")
     if mode == "compact" and isinstance(result, dict):
+        slot, _ = state._slot_mgr.resolve(args.get("project"))
+        if slot is not None:
+            _dedup_served_source(result, slot)
         return _compact_full_context(result, args.get("intent"))
     return result
 

--- a/tests/maison/test_09_dedup_source.py
+++ b/tests/maison/test_09_dedup_source.py
@@ -1,0 +1,31 @@
+"""get_full_context omet la source deja servie cette session.
+
+Tue le gaspillage `read -> get_full_context` (mesure 295x/3j) : l'agent lit une
+source via get_function_source, puis get_full_context sur le meme symbole la
+re-renvoyait. Teste sur le vrai chemin de dispatch, avec le cache CSC reel.
+"""
+from __future__ import annotations
+
+
+def test_get_full_context_dedupe_source_deja_servie(appeler):
+    # 1) l'agent lit la source (niveau 0 -> peuple le cache CSC de session)
+    appeler("get_function_source", name="calculer_frais", level=0)
+    # 2) get_full_context sur le meme symbole -> source OMISE, pointeur a la place
+    out = appeler("get_full_context", name="calculer_frais")
+    assert "already served" in out
+    assert "def calculer_frais" not in out          # la source complete n'y est plus
+    # 3) LOSSLESS : mode='full' rend toujours la source complete
+    plein = appeler("get_full_context", name="calculer_frais", mode="full")
+    assert "def calculer_frais" in plein
+    # 4) symbole JAMAIS lu -> pas de dedup (pas de faux positif)
+    autre = appeler("get_full_context", name="calculer_total")
+    assert "already served" not in autre
+
+
+def test_dedup_ne_touche_pas_les_deps(appeler):
+    """La dedup omet la source mais garde deps/dependents."""
+    appeler("get_function_source", name="calculer_frais", level=0)
+    out = appeler("get_full_context", name="calculer_frais", depth=1)
+    assert "already served" in out
+    # depth=1 -> le bundle contient toujours les cles deps/dependents
+    assert "dependencies" in out or "dependents" in out


### PR DESCRIPTION
Kills the measured `read->get_full_context` waste (295x over 3 days, ~44K tokens): the agent reads a symbol via get_function_source, then get_full_context on the same symbol re-sent the identical source.

When a symbol's source was served this session (the CSC session cache, populated at level 0) **and its body is unchanged**, get_full_context (compact mode) omits the source and leaves a recovery pointer; deps/dependents untouched. Lossless — `mode='full'` bypasses.

Two subtleties found by **proving it fires**, not by trusting green tests:
- Match on **body_hash** (the CSC's own unchanged-signal), not the source string — the two code paths format source differently, so a string compare silently never fires.
- The symbol name lives at `result['symbol']['name']`, not `result['name']`.

Net-positive guard (skip sources shorter than the pointer), no false positive on unread symbols. **Integration test dispatches through the real tool path on the cobaye project and asserts the source is actually omitted** — it would fail if the feature were a no-op.